### PR TITLE
BioImage.IO Core: Execute PlantSeg-compatible models by nickname

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - python-elf
     - napari
     - python-graphviz
+    - bioimageio.core>=0.6.5
 
 test:
   imports:

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -19,8 +19,9 @@ dependencies:
   - pytorch-cuda=12.1
   - cuda-version=12.3
   - python-elf
+  - pytest
   - pyqt
   - napari
   - python-graphviz
-  - bioimageio.core>=0.6.1
+  - bioimageio.core>=0.6.5
 # then `pip install -e .`

--- a/environment.yaml
+++ b/environment.yaml
@@ -17,3 +17,4 @@ dependencies:
   - python-elf
   - napari
   - python-graphviz
+  - bioimageio.core>=0.6.5

--- a/plantseg/models/__init__.py
+++ b/plantseg/models/__init__.py
@@ -1,0 +1,12 @@
+import logging
+import sys
+
+zoo_logger = logging.getLogger("PlantSeg Zoo")
+# Hardcode the log-level for now
+zoo_logger.setLevel(logging.INFO)
+
+# Add console handler (should show in GUI and on the console)
+stream_handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter('%(asctime)s [%(threadName)s] %(levelname)s %(name)s - %(message)s')
+stream_handler.setFormatter(formatter)
+zoo_logger.addHandler(stream_handler)

--- a/plantseg/models/zoo.py
+++ b/plantseg/models/zoo.py
@@ -9,20 +9,22 @@ from typing import List, Tuple, Optional, Self
 import pooch
 from pandas import DataFrame, concat
 from pydantic import BaseModel, Field, AliasChoices, model_validator
+from bioimageio.spec import InvalidDescr, load_description
+from bioimageio.spec.model.v0_4 import ModelDescr as ModelDescr_v0_4
+from bioimageio.spec.model.v0_5 import ModelDescr as ModelDescr_v0_5
+from bioimageio.spec.utils import download
 
 from plantseg import PATH_MODEL_ZOO, PATH_MODEL_ZOO_CUSTOM, PATH_PLANTSEG_MODELS
 from plantseg import FILE_CONFIG_TRAIN_YAML, FILE_BEST_MODEL_PYTORCH, FILE_LAST_MODEL_PYTORCH
 from plantseg.utils import get_class, load_config, save_config, download_files
-
-from bioimageio.spec import InvalidDescr, load_description
-from bioimageio.spec.model import ModelDescr_v0_4, ModelDescr_v0_5
-from bioimageio.spec.utils import download
+from plantseg.models import zoo_logger
 
 
 AUTHOR_PLANTSEG = 'plantseg'
 AUTHOR_USER = 'user'
 
 BIOIMAGE_IO_COLLECTION_URL = "https://raw.githubusercontent.com/bioimage-io/collection-bioimage-io/gh-pages/collection.json"
+
 
 class ModelZooRecord(BaseModel):
     """Model Zoo Record"""
@@ -290,6 +292,7 @@ class ModelZoo:
         model = self._create_model_by_config(model_config)
         if model_weights_path is None:
             model_weights_path = config_path.parent / FILE_BEST_MODEL_PYTORCH
+        zoo_logger.info(f"Loaded model from user specified weights: {model_weights_path}")
         return model, model_config, model_weights_path
 
     def get_model_by_name(self, model_name: str, model_update: bool = False):
@@ -297,6 +300,7 @@ class ModelZoo:
         self.check_models(model_name, update_files=model_update)
         config_path = self._get_model_config_path_by_name(model_name)
         model_weights_path = PATH_PLANTSEG_MODELS / model_name / FILE_BEST_MODEL_PYTORCH
+        zoo_logger.info(f"Loaded model from PlantSeg zoo: {model_name}")
         return self.get_model_by_config_path(config_path, model_weights_path)
 
     def get_model_by_id(self, model_id: str):
@@ -306,28 +310,23 @@ class ModelZoo:
         https://bioimage-io.github.io/collection-bioimage-io/rdfs/10.5281/zenodo.8401064/8429203/rdf.yaml
         """
 
-
         if not self.bioimageio_url_dict:
+            zoo_logger.info(f"Fetching BioImage.IO Model Zoo collection from {BIOIMAGE_IO_COLLECTION_URL}")
             collection_path = Path(pooch.retrieve(BIOIMAGE_IO_COLLECTION_URL, known_hash=None))
             with collection_path.open(encoding='utf-8') as f:
                 collection = json.load(f)
-            self.bioimageio_url_dict = {
-                entry["nickname"]: entry["rdf_source"]
-                for entry in collection["collection"] if entry["type"] == "model"
-            }
+            self.bioimageio_url_dict = {entry["nickname"]: entry["rdf_source"] for entry in collection["collection"] if entry["type"] == "model"}
 
         if model_id not in self.bioimageio_url_dict:
             raise ValueError(f"Model ID {model_id} not found in BioImage.IO Model Zoo")
 
         rdf_url = self.bioimageio_url_dict[model_id]
-        loaded_descr = load_description(rdf_url)
-        if isinstance(loaded_descr, InvalidDescr):
-            loaded_descr.validation_summary.display()
+        model_description = load_description(rdf_url)
+        if isinstance(model_description, InvalidDescr):
+            model_description.validation_summary.display()
             raise ValueError(f"Failed to load {model_id}")
-        elif not isinstance(loaded_descr, ModelDescr_v0_4) and not isinstance(loaded_descr, ModelDescr_v0_5):
+        elif not isinstance(model_description, ModelDescr_v0_4) and not isinstance(model_description, ModelDescr_v0_5):
             raise ValueError("This notebook expects a model description")
-        else:
-            model = loaded_descr
 
         model_config = {
             'name': 'UNet3D',
@@ -338,9 +337,14 @@ class ModelZoo:
             'num_groups': 8,
             'final_sigmoid': True,
         }
-        model_config.update(model.weights.pytorch_state_dict.kwargs)
+        if not model_description.weights.pytorch_state_dict:
+            raise ValueError(f"Model {model_id} does not have PyTorch weights")
+        model_config.update(model_description.weights.pytorch_state_dict.kwargs)
         model = self._create_model_by_config(model_config)
-        model_weights_path = download(model.weights.pytorch_state_dict.source).path
+        model_weights_path = download(model_description.weights.pytorch_state_dict.source).path
+
+        zoo_logger.info(f"Loaded model from BioImage.IO Model Zoo: {model_id}")
         return model, model_config, model_weights_path
+
 
 model_zoo = ModelZoo(PATH_MODEL_ZOO, PATH_MODEL_ZOO_CUSTOM)

--- a/plantseg/predictions/functional/predictions.py
+++ b/plantseg/predictions/functional/predictions.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
+from plantseg.pipeline import gui_logger
 from plantseg.models.zoo import model_zoo
 from plantseg.viewer.logging import napari_formatted_logging
 from plantseg.augment.transforms import get_test_augmentations
@@ -16,7 +17,8 @@ from plantseg.predictions.functional.utils import get_patch_halo, get_stride_sha
 
 def unet_predictions(
     raw: np.ndarray,
-    model_name: str,
+    model_name: Optional[str],
+    model_id: Optional[str],
     patch: Tuple[int, int, int] = (80, 160, 160),
     single_batch_mode: bool = True,
     device: str = 'cuda',
@@ -45,10 +47,17 @@ def unet_predictions(
     Returns:
         np.ndarray: The predicted boundaries as a 3D (Z, Y, X) or 4D (C, Z, Y, X) array, normalized between 0 and 1.
     """
-    if config_path is not None:
+    if config_path is not None:  # Safari mode for custom models outside zoos
+        gui_logger.info('Safari prediction: Running model from custom config path.')
         model, model_config, model_path = model_zoo.get_model_by_config_path(config_path, model_weights_path)
-    else:
+    elif model_id is not None:  # BioImage.IO zoo mode
+        gui_logger.info('BioImage.IO prediction: Running model from BioImage.IO model zoo.')
+        model, model_config, model_path = model_zoo.get_model_by_id(model_id)
+    elif model_name is not None:  # PlantSeg zoo mode
+        gui_logger.info('Zoo prediction: Running model from PlantSeg official zoo.')
         model, model_config, model_path = model_zoo.get_model_by_name(model_name, model_update=model_update)
+    else:
+        raise ValueError('Either `model_name` or `model_id` or `model_path` must be provided.')
     state = torch.load(model_path, map_location='cpu')
 
     if 'model_state_dict' in state:  # Model weights format may vary between versions

--- a/plantseg/viewer/widget/predictions.py
+++ b/plantseg/viewer/widget/predictions.py
@@ -55,6 +55,8 @@ def unet_predictions_wrapper(raw, device, **kwargs):
                       'tooltip': f'Select a pretrained model. '
                                  f'Current model description: {model_zoo.get_model_description(model_zoo.list_models()[0])}',
                       'choices': model_zoo.list_models()},
+          model_id={'label': 'Select model',
+                    'tooltip': 'Select a model from BioImage.IO model zoo.'},
           patch_size={'label': 'Patch size',
                       'tooltip': 'Patch size use to processed the data.'},
           patch_halo={'label': 'Patch halo',
@@ -67,6 +69,7 @@ def unet_predictions_wrapper(raw, device, **kwargs):
 def widget_unet_predictions(viewer: Viewer,
                             image: Image,
                             model_name: str = model_zoo.list_models()[0],
+                            model_id: str = '',
                             dimensionality: str = ALL,
                             modality: str = ALL,
                             output_type: str = ALL,
@@ -85,6 +88,7 @@ def widget_unet_predictions(viewer: Viewer,
 
     layer_type = 'image'
     step_kwargs = dict(model_name=model_name,
+                       model_id=model_id,
                        patch=patch_size,
                        patch_halo=patch_halo,
                        single_batch_mode=single_patch,

--- a/tests/test_bioimageio.py
+++ b/tests/test_bioimageio.py
@@ -1,4 +1,25 @@
+import torch
 from plantseg.models.zoo import model_zoo
 
-def test_get_model_by_id():
-    model_zoo.get_model_by_id('efficient-chipmunk')
+
+def test_get_3D_model_by_id():
+    """Try to load a 3D model from the BioImage.IO model zoo.
+
+    Load Qin Yu's nuclear segmentation model 'efficient-chipmunk'.
+    """
+    model, model_config, model_path = model_zoo.get_model_by_id('efficient-chipmunk')
+    state = torch.load(model_path, map_location='cpu')
+    if 'model_state_dict' in state:  # Model weights format may vary between versions
+        state = state['model_state_dict']
+    model.load_state_dict(state)
+
+def test_get_2D_model_by_id():
+    """Try to load a 2D model from the BioImage.IO model zoo.
+
+    Load Adrian's 2D cell-wall segmentation model 'pioneering-rhino'.
+    """
+    model, model_config, model_path = model_zoo.get_model_by_id('pioneering-rhino')
+    state = torch.load(model_path, map_location='cpu')
+    if 'model_state_dict' in state:  # Model weights format may vary between versions
+        state = state['model_state_dict']
+    model.load_state_dict(state)

--- a/tests/test_bioimageio.py
+++ b/tests/test_bioimageio.py
@@ -1,0 +1,4 @@
+from plantseg.models.zoo import model_zoo
+
+def test_get_model_by_id():
+    model_zoo.get_model_by_id('efficient-chipmunk')


### PR DESCRIPTION
## New: Predict with models from BioImage.IO Model Zoo

After Zenodo failed BioImage.IO and BioImage.IO's storage moved to EBI, this PR:

- is the first attempt for https://github.com/kreshuklab/plant-seg/issues/210
- makes prediction with models from BioImage.IO Model Zoo possible
  - limited to PlantSeg-compatible models, i.e. `UNet3D`s and `UNet2D`s trained with `pytorch-3dunet`
  - depend on `bioimageio.core` package now, but conda has no "extra"s like pip so it's made compulsory

The next step is to discuss with BioImage.IO team about filtering models and make PlantSeg community partner.

![image](https://github.com/kreshuklab/plant-seg/assets/17722010/9f9b3923-ffd0-4632-ba30-8770077239af)

Prediction with PlantSeg Custom/Official models in PlantSeg Zoo is not affected:

![image](https://github.com/kreshuklab/plant-seg/assets/17722010/db25aa18-4ba0-4cc6-a49f-29f05ca00bc8)
