### PR TITLE
Recommend users a halo for U-Nets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@ __pycache__/
 # Conda build
 plantseg.egg-info/
 dist/
-docs/_build/
 
 # Dev
 settings.json
+
+# Docs
+.cache/
+docs/_build/

--- a/plantseg/models/zoo.py
+++ b/plantseg/models/zoo.py
@@ -487,5 +487,9 @@ class ModelZoo:
         model, _, _ = self.get_model_by_name(model_name)
         return self.compute_3D_halo_for_pytorch3dunet(model)
 
+    def compute_3D_halo_for_bioimageio_models(self, model_id: str) -> tuple[int, int, int]:
+        model, _, _ = self.get_model_by_id(model_id)
+        return self.compute_3D_halo_for_pytorch3dunet(model)
+
 
 model_zoo = ModelZoo(PATH_MODEL_ZOO, PATH_MODEL_ZOO_CUSTOM)

--- a/plantseg/models/zoo.py
+++ b/plantseg/models/zoo.py
@@ -15,6 +15,9 @@ from bioimageio.spec.model.v0_4 import ModelDescr as ModelDescr_v0_4
 from bioimageio.spec.model.v0_5 import ModelDescr as ModelDescr_v0_5
 from bioimageio.spec.utils import download
 
+from torch.nn import MaxPool3d, Conv3d, Module
+from plantseg.training.model import InterpolateUpsampling
+
 from plantseg.utils import get_class, load_config, save_config, download_files
 from plantseg.models import zoo_logger
 
@@ -425,6 +428,50 @@ class ModelZoo:
         return sorted(
             list(set(self.get_bioimageio_zoo_all_model_names()) - set(self.get_bioimageio_zoo_plantseg_model_names()))
         )
+
+    def _flatten_module(self, module: Module) -> List[Module]:
+        """Recursively flatten a PyTorch nn.Module into a list of its elemental layers."""
+        layers = []
+        for child in module.children():
+            if not list(child.children()):  # Check if the module has no children
+                layers.append(child)
+            else:  # Recursively flatten the child that has its own submodules
+                layers.extend(self._flatten_module(child))
+        return layers
+
+    def compute_halo(self, module: Module) -> int:
+        """Compute the halo size for a UNet model.
+
+        The halo is computed based on the increase and decrease in effective spatial resolution
+        as the network processes inputs through successive pooling and upsampling layers,
+        respectively. Each convolutional layer's contribution to the halo depends on its level
+        in the network hierarchy, defined by the number of max-pool layers minus the number
+        of up-conv layers encountered along the longest path from the input to that layer.
+
+        Args:
+            module (nn.Module): The UNet model, either UNet2D or UNet3D.
+
+        Returns:
+            int: Halo size for one side in each dimension.
+
+        References:
+            - For further details on how halos are calculated in the context of neural networks,
+            see: https://doi.org/10.6028/jres.126.009
+        """
+        module_list = self._flatten_module(module)
+        level = 0
+        conv_contribution = []
+
+        for mod in module_list:
+            if isinstance(mod, MaxPool3d):
+                level += 1
+            elif isinstance(mod, InterpolateUpsampling):
+                level -= 1
+            elif isinstance(mod, Conv3d):
+                conv_contribution.append(2**level * (mod.kernel_size[0] // 2))
+
+        halo = sum(conv_contribution)
+        return halo
 
 
 model_zoo = ModelZoo(PATH_MODEL_ZOO, PATH_MODEL_ZOO_CUSTOM)

--- a/plantseg/viewer/widget/predictions.py
+++ b/plantseg/viewer/widget/predictions.py
@@ -96,7 +96,7 @@ def widget_unet_predictions(viewer: Viewer,
                             modality: str = ALL,
                             output_type: str = ALL,
                             patch_size: tuple[int, int, int] = (80, 170, 170),
-                            patch_halo: tuple[int, int, int] = (8, 16, 16),
+                            patch_halo: tuple[int, int, int] = model_zoo.compute_3D_halo_for_zoo_models(model_zoo.list_models()[0]),
                             single_patch: bool = False,
                             device: str = ALL_DEVICES[0], ) -> Future[LayerDataTuple]:
     if mode == PREDICTION_MODE_P:
@@ -210,6 +210,7 @@ def _on_model_name_changed(model_name: str):
     if description is None:
         description = 'No description available for this model.'
     widget_unet_predictions.model_name.tooltip = f'Select a pretrained model. Current model description: {description}'
+    widget_unet_predictions.patch_halo.value = model_zoo.compute_3D_halo_for_zoo_models(model_name)
 
 
 def _compute_multiple_predictions(image, patch_size, patch_halo, device, use_custom_models=True):

--- a/tests/test_bioimageio.py
+++ b/tests/test_bioimageio.py
@@ -7,7 +7,7 @@ def test_get_3D_model_by_id():
 
     Load Qin Yu's nuclear segmentation model 'efficient-chipmunk'.
     """
-    model, model_config, model_path = model_zoo.get_model_by_id('efficient-chipmunk')
+    model, _, model_path = model_zoo.get_model_by_id('efficient-chipmunk')
     state = torch.load(model_path, map_location='cpu')
     if 'model_state_dict' in state:  # Model weights format may vary between versions
         state = state['model_state_dict']
@@ -18,8 +18,14 @@ def test_get_2D_model_by_id():
 
     Load Adrian's 2D cell-wall segmentation model 'pioneering-rhino'.
     """
-    model, model_config, model_path = model_zoo.get_model_by_id('pioneering-rhino')
+    model, _, model_path = model_zoo.get_model_by_id('pioneering-rhino')
     state = torch.load(model_path, map_location='cpu')
     if 'model_state_dict' in state:  # Model weights format may vary between versions
         state = state['model_state_dict']
     model.load_state_dict(state)
+
+def test_halo_computation_for_bioimageio_model():
+    """Compute the halo for a BioImage.IO model."""
+    model, _, _ = model_zoo.get_model_by_id('efficient-chipmunk')
+    halo = model_zoo.compute_halo(model)
+    assert halo == 44


### PR DESCRIPTION
This PR provides users a theoretical minimum halo for U-Nets, but in practice a smaller halo may also work well.

## Changes

This PR attempts to fix #251 

- [x] Compute a halo based on model architecture
- [x] Recommend users a halo for selected PlantSeg-compatible models (can be toggled off)
- [ ] Recommend users a halo based on images and architecture

![image](https://github.com/kreshuklab/plant-seg/assets/17722010/83f7a8b5-49f6-472c-ad19-494b5ddadd5f)

## Definition

![image](https://github.com/kreshuklab/plant-seg/assets/17722010/fddbc73c-3fb9-4a02-a689-5f40922de523)

Reference: [Exact Tile-Based Segmentation Inference for Images Larger than GPU Memory](https://doi.org/10.6028/jres.126.009)