### PR TITLE
Test: Fix always-skipped test and misleading name

### DIFF
--- a/plantseg/viewer/widget/predictions.py
+++ b/plantseg/viewer/widget/predictions.py
@@ -79,7 +79,8 @@ def unet_predictions_wrapper(raw, device, **kwargs):
           patch_size={'label': 'Patch size',
                       'tooltip': 'Patch size use to processed the data.'},
           patch_halo={'label': 'Patch halo',
-                      'tooltip': 'Patch halo is extra padding for correct prediction on image boarder.'},
+                      'tooltip': 'Patch halo is extra padding for correct prediction on image boarder.'
+                                 'The value is for one side of a given dimension.',},
           recommend_halo={'label': 'Recommend halo',
                         'tooltip': 'Refresh the halo based on the selected model.',
                         'widget_type': 'RadioButtons',

--- a/tests/test_model_zoo.py
+++ b/tests/test_model_zoo.py
@@ -18,7 +18,7 @@ MODEL_NAMES = [
 
 class TestModelZoo:
     @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Github workflows do not allow model download for security reason")
-    def test_model_zoo(self):
+    def test_model_output_normalisation(self):
         for model_name in MODEL_NAMES:
             model, _, model_path = model_zoo.get_model_by_name(model_name, model_update=True)
             state = torch.load(model_path, map_location='cpu')

--- a/tests/test_model_zoo.py
+++ b/tests/test_model_zoo.py
@@ -1,18 +1,23 @@
-import pytest
+import os
 import torch
+import pytest
 
 from plantseg.training.model import UNet2D
 from plantseg.models.zoo import model_zoo
 
+IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
+
 # test some modes (3D and 2D)
-MODEL_NAMES = ['confocal_2D_unet_ovules_ds2x',
-               'generic_confocal_3D_unet',
-               'lightsheet_2D_unet_root_ds1x',
-               'generic_light_sheet_3D_unet']
+MODEL_NAMES = [
+    'confocal_2D_unet_ovules_ds2x',
+    'generic_confocal_3D_unet',
+    'lightsheet_2D_unet_root_ds1x',
+    'generic_light_sheet_3D_unet',
+]
 
 
 class TestModelZoo:
-    @pytest.mark.skip("github workflows do not allow to download models for security reason")
+    @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Github workflows do not allow model download for security reason")
     def test_model_zoo(self):
         for model_name in MODEL_NAMES:
             model, _, model_path = model_zoo.get_model_by_name(model_name, model_update=True)


### PR DESCRIPTION
- Fix #261 

```python
$ pytest
============================= test session starts ==============================
platform linux -- Python 3.11.9, pytest-8.2.1, pluggy-1.5.0
PyQt5 5.15.9 -- Qt runtime 5.15.8 -- Qt compiled 5.15.8
rootdir: /g/kreshuk/yu/repositories/plant-seg-doc
plugins: napari-plugin-engine-0.2.0, npe2-0.7.5, napari-0.4.19.post1, anyio-4.2.0, qt-4.4.0, xdist-3.5.0
collected 32 items                                                             

tests/test_bioimageio.py ...                                             [  9%]
tests/test_data_processing.py ........                                   [ 34%]
tests/test_io_zarr.py .....                                              [ 50%]
tests/test_model.py ...                                                  [ 59%]
tests/test_model_zoo.py .                                                [ 62%]
tests/test_network_predictions.py ..                                     [ 68%]
tests/test_pipeline_executor.py ...                                      [ 78%]
tests/test_widget_preprocessing.py .......                               [100%]

=============================== warnings summary ===============================
../../miniconda3/envs/plant-seg-bioimage-io/lib/python3.11/site-packages/jupyter_client/connect.py:22
  /g/kreshuk/yu/miniconda3/envs/plant-seg-bioimage-io/lib/python3.11/site-packages/jupyter_client/connect.py:22: DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
  given by the platformdirs library.  To remove this warning and
  see the appropriate new directories, set the environment variable
  `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
  The use of platformdirs will be the default in `jupyter_core` v6
    from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir, secure_write

tests/test_data_processing.py::TestDataProcessing::test_preprocessing_default_voxel_size
  /g/kreshuk/yu/repositories/plant-seg-doc/plantseg/io/h5.py:22: RuntimeWarning: Voxel size not found, returning default [1.0, 1.0. 1.0]
    warnings.warn('Voxel size not found, returning default [1.0, 1.0. 1.0]', RuntimeWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================== 32 passed, 2 warnings in 81.70s (0:01:21) ===================
```