### PR TITLE
chore: migrate from `bumpversion` to `bump-my-version`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,0 @@
-[bumpversion]
-current_version = 1.8.0
-commit = True
-tag = True
-tag_name = {new_version}
-
-[bumpversion:file:plantseg/__version__.py]

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -26,6 +26,7 @@ dependencies:
   - python-graphviz
   - bioimageio.core>=0.6.5
   - pre-commit
+  - bump-my-version
   - mkdocs-material
   - mkdocs-autorefs
   - mkdocs-git-revision-date-localized-plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,28 @@
 [tool.typos.default.extend-words]
-nd = "nd"  # N-dimensional (ND)
-ome = "ome"  # Open Microscopy Environment (OME)
-datas = "datas"  # pyinstaller
+nd = "nd"       # N-dimensional (ND)
+ome = "ome"     # Open Microscopy Environment (OME)
+datas = "datas" # pyinstaller
 
 [tool.ruff]
 line-length = 120
 
 [tool.ruff.format]
 quote-style = "preserve"
+
+[tool.bumpversion]
+current_version = "1.8.0"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
+serialize = ["{major}.{minor}.{patch}"]
+
+[[tool.bumpversion.files]]
+filename = "plantseg/__version__.py"
+search = "{current_version}"
+replace = "{new_version}"
+
+# Optional git settings
+tag = true
+commit = true
+tag_message = "Bump version: {current_version} → {new_version}"
+allow_dirty = false
+message = "Bump version: {current_version} → {new_version}"
+commit_args = ""


### PR DESCRIPTION
## Changes

- `bumpversion` and `bump2version` are both no longer maintained. Switch to _Bump My Version_.
- surprisingly I can now combine `.bumpversion.toml` into `pyproject.toml`
- manually delete tags `v.1.0.0` and `v1.0.0`, and create `1.0.0` 
- also I just became aware of _Conventional Commits_

### Log

```shell
$ git show-ref --tags
d3fa7165e780683b4daf4ed9bc12bce83ad80252 refs/tags/1.0.1
b304df5d35e725391caf27e4f7c174e2a306f65d refs/tags/1.0.10
fac3a535e7c6cda2798db8746caf6e1f114e44db refs/tags/1.0.2
e18e885927315726ad0bba96d5e4342e33cf1d35 refs/tags/1.0.3
90a6db743529b662f0d67997a21202db7542599f refs/tags/1.0.4
...
...
68b51f9d77ead006aa5db95bfd3599e3cd24ff0b refs/tags/1.7.0
49ced6ae075bfa62c1ad6ef08683723504baf7de refs/tags/1.7.1
c44082c8360bdec85a1ec3beb9b053b6bb5a5ba5 refs/tags/1.8.0
2eafa9ab7d91b3dca1552dee3ceb6094a13c5d4b refs/tags/v.1.0.0
2eafa9ab7d91b3dca1552dee3ceb6094a13c5d4b refs/tags/v1.0.0

$ git tag 1.0.0 2eafa9ab7d91b3dca1552dee3ceb6094a13c5d4b

$ git tag -d v.1.0.0
Deleted tag 'v.1.0.0' (was 2eafa9a)

$ git tag -d v1.0.0
Deleted tag 'v1.0.0' (was 2eafa9a)

$ git push origin :refs/tags/v.1.0.0
remote: This repository moved. Please use the new location:
remote:   git@github.com:kreshuklab/plant-seg.git
To github.com:hci-unihd/plant-seg.git
 - [deleted]         v.1.0.0

$ git push origin :refs/tags/v1.0.0
remote: This repository moved. Please use the new location:
remote:   git@github.com:kreshuklab/plant-seg.git
To github.com:hci-unihd/plant-seg.git
 - [deleted]         v1.0.0

$ git push origin 1.0.0
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
remote: This repository moved. Please use the new location:
remote:   git@github.com:kreshuklab/plant-seg.git
To github.com:hci-unihd/plant-seg.git
 * [new tag]         1.0.0 -> 1.0.0
```