### PR TITLE
fix(docs): teach Qt to find napari icons

### DIFF
--- a/.github/workflows/build-deploy-book.yml
+++ b/.github/workflows/build-deploy-book.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - qy/mkdocs-author
+      - qy/fix-docs-qt-napari-path
 
 permissions:
   contents: write

--- a/docs/snippets/napari_widgets_render.py
+++ b/docs/snippets/napari_widgets_render.py
@@ -1,5 +1,6 @@
 from PyQt5 import QtGui, QtCore
 from napari.qt import get_stylesheet
+from napari.resources._icons import _theme_path
 import base64
 
 css_style = """
@@ -20,6 +21,9 @@ css_style = """
         }
     </style>
     """
+
+QtCore.QDir.addSearchPath(f'theme_dark', str(_theme_path('dark')))
+QtCore.QDir.addSearchPath(f'theme_light', str(_theme_path('light')))
 
 
 def get_widget_title(widget) -> str:
@@ -50,7 +54,6 @@ def _render_widget(widget, theme="dark"):
     widget.native.render(pixmap)
     qimage = pixmap.toImage()
     widget.close()
-
     buffer = QtCore.QBuffer()
     buffer.open(QtCore.QBuffer.ReadWrite)
     qimage.save(buffer, "PNG")

--- a/docs/snippets/napari_widgets_render.py
+++ b/docs/snippets/napari_widgets_render.py
@@ -22,8 +22,8 @@ css_style = """
     </style>
     """
 
-QtCore.QDir.addSearchPath(f'theme_dark', str(_theme_path('dark')))
-QtCore.QDir.addSearchPath(f'theme_light', str(_theme_path('light')))
+QtCore.QDir.addSearchPath('theme_dark', str(_theme_path('dark')))
+QtCore.QDir.addSearchPath('theme_light', str(_theme_path('light')))
 
 
 def get_widget_title(widget) -> str:


### PR DESCRIPTION
This PR fixes a rabbit-hole issue that I encountered when trying to run the PlantSeg documentation build. 


### Issue

Qt wasn't able to find the icons napari build.

```pytb
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_light:/minus_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_light:/minus_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/plus_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/plus_50.svg', because: No such file or directory
```

### Solution

To resolve the issue, simply add the following line to set the search path for Qt:

```python
PyQt5.QtCore.QDir.addSearchPath(f'theme_{name}', str(_theme_path(name)))
```

### Cause

The reason why Qt inside `magicgui` widgets couldn’t locate the SVG file built by Napari is that `QApplication` never initializes in the context of an MkDocs build using `markdown-exec`.

Under normal usage, `napari._qt.qt_event_loop.get_app()` gets the singleton Napari app, and the line `PyQt5.QtCore.QDir.addSearchPath(f'theme_{name}', str(_theme_path(name)))` within this context allows Qt to recognize the temporary path for all SVGs, such as:

```bash
/home/qyu/.cache/napari/plant-seg_1bbf9c2c85c974192c72e305681854d064a243cf/_themes/dark
```

To verify this, you can simply instantiate a Napari viewer with `viewer = napari.Viewer()` before calling `.setStyleSheet()`, which also resolves the problem.

### Discussion

- [Where is `url(“theme_{{ id }}:/drop_down_50.svg”)` from Napari?](https://forum.image.sc/t/where-is-url-theme-id-drop-down-50-svg-from-napari/97242/7)
- https://github.com/pawamoy/markdown-exec/issues/48
- https://github.com/PyQt5/PyQt/issues/188

<details>

<summary>Logs before this PR</summary>

### Logs before this PR

```pytb
(plant-seg) [qyu@kreshuk-gpu1 plant-seg]$ mkdocs serve
INFO    -  Building documentation...
INFO    -  git-committers plugin ENABLED
INFO    -  git-committers: found page authors cache file - loading it
INFO    -  Cleaning site directory
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
             - snippets/napari/dataprocessing/rescale.md
INFO    -  DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
           given by the platformdirs library.  To remove this warning and
           see the appropriate new directories, set the environment variable
           `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
           The use of platformdirs will be the default in `jupyter_core` v6
             File "/yu/miniconda3/envs/plant-seg/lib/python3.11/site-packages/jupyter_core/utils/__init__.py", line 90, in deprecation
               warnings.warn(message, DeprecationWarning, stacklevel=stacklevel + 1)
             File "/yu/miniconda3/envs/plant-seg/lib/python3.11/site-packages/jupyter_client/connect.py", line 22, in
               from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir, secure_write
WARNING: Qt: Session management error: Authentication Rejected, reason : None of the authentication protocols specified are supported and host-based authentication failed
WARNING:vispy:Qt: Session management error: Authentication Rejected, reason : None of the authentication protocols specified are supported and host-based authentication failed
2024-06-05 19:37:06,242 [MainThread] INFO PlantSeg Zoo - Fetching BioImage.IO Model Zoo collection from https://raw.githubusercontent.com/bioimage-io/collection-bioimage-io/gh-pages/collection.json
INFO:PlantSeg Zoo:Fetching BioImage.IO Model Zoo collection from https://raw.githubusercontent.com/bioimage-io/collection-bioimage-io/gh-pages/collection.json
2024-06-05 19:37:06,249 [MainThread] INFO PlantSeg Zoo - Loaded model from PlantSeg zoo: generic_confocal_3D_unet
INFO:PlantSeg Zoo:Loaded model from PlantSeg zoo: generic_confocal_3D_unet
2024-06-05 19:37:06,304 [MainThread] INFO PlantSeg Zoo - Loaded model from user specified weights: /home/qyu/.plantseg_models/generic_confocal_3D_unet/best_checkpoint.pytorch
INFO:PlantSeg Zoo:Loaded model from user specified weights: /home/qyu/.plantseg_models/generic_confocal_3D_unet/best_checkpoint.pytorch
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_light:/drop_down_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_light:/drop_down_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_light:/drop_down_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_light:/drop_down_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_light:/drop_down_50.svg', because: No such file or directory
...
...
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/plus_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/plus_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/plus_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/plus_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/minus_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/minus_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/minus_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/minus_50.svg', because: No such file or directory
INFO    -  Doc file 'chapters/getting_started/troubleshooting.md' contains a link '#problems-with---headless-and-daskdistributed', but there is no such anchor on this page.
INFO    -  git-committers: saving page authors cache file
INFO    -  Documentation built in 45.24 seconds
INFO    -  [19:37:29] Watching paths for changes: 'docs', 'mkdocs.yml'
INFO    -  [19:37:29] Serving on http://127.0.0.1:8000/plant-seg/
WARNING -  [19:37:29] "GET /plant-seg/images/favicon.ico HTTP/1.1" code 404
INFO    -  [19:37:29] Browser connected: http://127.0.0.1:8000/plant-seg/chapters/plantseg_interactive_napari/data_processing/
INFO    -  [19:37:36] Detected file changes
INFO    -  Building documentation...
INFO    -  git-committers plugin ENABLED
INFO    -  git-committers: found page authors cache file - loading it
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
             - snippets/napari/dataprocessing/rescale.md
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_light:/drop_down_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_light:/drop_down_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_light:/drop_down_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_light:/drop_down_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_light:/drop_down_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_light:/drop_down_50.svg', because: No such file or directory
...
...
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/drop_down_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/plus_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/plus_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/plus_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/plus_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/minus_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/minus_50.svg', because: No such file or directory
WARNING: Cannot open file '/yu/repositories/plant-seg/theme_dark:/minus_50.svg', because: No such file or directory
WARNING:vispy:Cannot open file '/yu/repositories/plant-seg/theme_dark:/minus_50.svg', because: No such file or directory
INFO    -  Doc file 'chapters/getting_started/troubleshooting.md' contains a link '#problems-with---headless-and-daskdistributed', but there is no such anchor on this page.
INFO    -  git-committers: saving page authors cache file
INFO    -  Documentation built in 32.14 seconds
INFO    -  [19:38:08] Reloading browsers
INFO    -  [19:38:09] Browser connected: http://127.0.0.1:8000/plant-seg/chapters/plantseg_interactive_napari/data_processing/
```

</details>

<details>

<summary>Logs after this PR</summary>

### Logs after this PR

```pytb
(plant-seg) [qyu@kreshuk-gpu1 plant-seg]$ mkdocs serve
INFO    -  Building documentation...
INFO    -  git-committers plugin ENABLED
INFO    -  git-committers: found page authors cache file - loading it
INFO    -  Cleaning site directory
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
             - snippets/napari/dataprocessing/rescale.md
INFO    -  DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
           given by the platformdirs library.  To remove this warning and
           see the appropriate new directories, set the environment variable
           `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
           The use of platformdirs will be the default in `jupyter_core` v6
             File "/yu/miniconda3/envs/plant-seg/lib/python3.11/site-packages/jupyter_core/utils/__init__.py", line 90, in deprecation
               warnings.warn(message, DeprecationWarning, stacklevel=stacklevel + 1)
             File "/yu/miniconda3/envs/plant-seg/lib/python3.11/site-packages/jupyter_client/connect.py", line 22, in
               from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir, secure_write
WARNING: Qt: Session management error: Authentication Rejected, reason : None of the authentication protocols specified are supported and host-based authentication failed
WARNING:vispy:Qt: Session management error: Authentication Rejected, reason : None of the authentication protocols specified are supported and host-based authentication failed
2024-06-05 19:43:23,834 [MainThread] INFO PlantSeg Zoo - Fetching BioImage.IO Model Zoo collection from https://raw.githubusercontent.com/bioimage-io/collection-bioimage-io/gh-pages/collection.json
INFO:PlantSeg Zoo:Fetching BioImage.IO Model Zoo collection from https://raw.githubusercontent.com/bioimage-io/collection-bioimage-io/gh-pages/collection.json
2024-06-05 19:43:24,152 [MainThread] INFO PlantSeg Zoo - Loaded model from PlantSeg zoo: generic_confocal_3D_unet
INFO:PlantSeg Zoo:Loaded model from PlantSeg zoo: generic_confocal_3D_unet
2024-06-05 19:43:24,198 [MainThread] INFO PlantSeg Zoo - Loaded model from user specified weights: /home/qyu/.plantseg_models/generic_confocal_3D_unet/best_checkpoint.pytorch
INFO:PlantSeg Zoo:Loaded model from user specified weights: /home/qyu/.plantseg_models/generic_confocal_3D_unet/best_checkpoint.pytorch
INFO    -  Doc file 'chapters/getting_started/troubleshooting.md' contains a link '#problems-with---headless-and-daskdistributed', but there is no such anchor on this page.
INFO    -  git-committers: saving page authors cache file
INFO    -  Documentation built in 45.88 seconds
INFO    -  [19:43:47] Watching paths for changes: 'docs', 'mkdocs.yml'
INFO    -  [19:43:47] Serving on http://127.0.0.1:8000/plant-seg/
INFO    -  [19:43:47] Browser connected: http://127.0.0.1:8000/plant-seg/chapters/plantseg_interactive_napari/data_processing/
```

</details>
