### PR TITLE
fixes PlantSeg crash on apple silicon #273

### DIFF
--- a/plantseg/__init__.py
+++ b/plantseg/__init__.py
@@ -1,5 +1,6 @@
 """Initialise model registry at startup"""
 
+import torch # required to patch #273
 from os import getenv
 from pathlib import Path
 import yaml

--- a/plantseg/__init__.py
+++ b/plantseg/__init__.py
@@ -1,6 +1,6 @@
 """Initialise model registry at startup"""
 
-import torch # required to patch #273
+import torch  # required to patch #273
 from os import getenv
 from pathlib import Path
 import yaml

--- a/plantseg/__init__.py
+++ b/plantseg/__init__.py
@@ -1,8 +1,8 @@
 """Initialise model registry at startup"""
 
-import torch  # required to patch #273
 from os import getenv
 from pathlib import Path
+import torch  # noqa: F401; required to patch #273
 import yaml
 
 


### PR DESCRIPTION
I was able to reproduce this in the plantseg env (but not in a clean env) 
The issue is the order of import of numpy/torch, and the fact that we are reading the state dict from file. 

## This will fail
```python
import numpy as np
import torch

model = torch.nn.Conv3d(64, 32, kernel_size=(3, 3, 3))

torch.save(model.state_dict(), "model.pth")
model.load_state_dict(torch.load("model.pth"))
```

## These two will work 
```python
import torch
import numpy as np

model = torch.nn.Conv3d(64, 32, kernel_size=(3, 3, 3))

torch.save(model.state_dict(), "model.pth")
model.load_state_dict(torch.load("model.pth"))
```

```python
import numpy as np
import torch

model = torch.nn.Conv3d(64, 32, kernel_size=(3, 3, 3))

state_dict = model.state_dict()
model.load_state_dict(state_dict)
```

## Solution
For now importing `torch` in the `__init__.py` works and has no drawbacks. 