### PR TITLE
fix(installation): remove old configs if `KeyError` | macOS installation

### DIFF
--- a/docs/chapters/getting_started/installation.md
+++ b/docs/chapters/getting_started/installation.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites for Conda package
 
-* Linux, Windows, MacOS (not all features are available on MacOS)
+* Linux, Windows, macOS (not all features are available on macOS)
 * (Optional) Nvidia GPU with official Nvidia drivers installed for GPU acceleration
 
 ## Install Mamba
@@ -29,30 +29,40 @@ The easiest way to install PlantSeg is by using the [conda (Anaconda)](https://w
     Please refer to the [Miniforge repo](https://github.com/conda-forge/miniforge) for more information, troubleshooting and uninstallation instructions.
     The miniforge installation file `Miniforge3-*.sh` can be deleted now.
 
-=== "Windows/MacOS"
+=== "Windows/macOS"
     The first step required to use the pipeline is installing mamba. The installation can be done by downloading the installer from the [Miniforge repo](https://github.com/conda-forge/miniforge). There you can find the download links for the latest version of Miniforge, troubleshooting and uninstallation instructions.
 
 ## Install PlantSeg using Mamba
 
 PlantSeg can be installed directly by executing in the terminal (or PowerShell on Windows). For `conda` users, the command is identical, just replace `mamba` with `conda`.
 
-* GPU version, CUDA=12.x
+=== "Linux/Windows"
 
-    ```bash
-    mamba create -n plant-seg -c pytorch -c nvidia -c conda-forge pytorch pytorch-cuda=12.1 pyqt plant-seg --no-channel-priority
-    ```
+    * NVIDIA GPU version, CUDA=12.x
 
-* GPU version, CUDA=11.x
+        ```bash
+        mamba create -n plant-seg -c pytorch -c nvidia -c conda-forge pytorch pytorch-cuda=12.1 pyqt plant-seg --no-channel-priority
+        ```
 
-    ```bash
-    mamba create -n plant-seg -c pytorch -c nvidia -c conda-forge pytorch pytorch-cuda=11.8 pyqt plant-seg --no-channel-priority
-    ```
+    * NVIDIA GPU version, CUDA=11.x
 
-* CPU version
+        ```bash
+        mamba create -n plant-seg -c pytorch -c nvidia -c conda-forge pytorch pytorch-cuda=11.8 pyqt plant-seg --no-channel-priority
+        ```
 
-    ```bash
-    mamba create -n plant-seg -c pytorch -c nvidia -c conda-forge pytorch cpuonly pyqt plant-seg --no-channel-priority
-    ```
+    * CPU version
+
+        ```bash
+        mamba create -n plant-seg -c pytorch -c nvidia -c conda-forge pytorch cpuonly pyqt plant-seg --no-channel-priority
+        ```
+
+=== "macOS"
+
+    * Apple silicon version
+
+        ```bash
+        mamba create -n plant-seg -c pytorch -c conda-forge python=3.11 pytorch::pytorch pyqt plant-seg --no-channel-priority
+        ```
 
 If you used older versions of PlantSeg, please delete the old config files in `~/.plantseg_models/configs/` after installing new PlantSeg.
 

--- a/docs/chapters/getting_started/installation.md
+++ b/docs/chapters/getting_started/installation.md
@@ -54,6 +54,8 @@ PlantSeg can be installed directly by executing in the terminal (or PowerShell o
     mamba create -n plant-seg -c pytorch -c nvidia -c conda-forge pytorch cpuonly pyqt plant-seg --no-channel-priority
     ```
 
+If you used older versions of PlantSeg, please delete the old config files in `~/.plantseg_models/configs/` after installing new PlantSeg.
+
 The above command will create new conda environment `plant-seg` together with all required dependencies.
 
 Please refer to the [PyTorch](https://pytorch.org/get-started/locally/) website for more information on the available versions of PyTorch and the required CUDA version. The GPU version of Pytorch will also work on CPU only machines but has a much larger installation on disk.

--- a/plantseg/run_plantseg.py
+++ b/plantseg/run_plantseg.py
@@ -21,8 +21,16 @@ def create_parser():
 def launch_gui():
     """Launch the GUI configurator."""
     from plantseg.legacy_gui.plantsegapp import PlantSegApp
+    from plantseg import PATH_CONFIGS
 
-    PlantSegApp()
+    try:
+        PlantSegApp()
+    except KeyError as e:
+        print(f"If you used PlantSeg before, {PATH_CONFIGS} is checked for your custom configurations.")
+        print(f"If KeyError happens, just delete {PATH_CONFIGS} and a new default configs will be put there.")
+        docs_link = "https://kreshuklab.github.io/plant-seg/chapters/getting_started/troubleshooting/#missing-configuration-key-errors"
+        print(f"For more information, please visit {docs_link}")
+        raise e
 
 
 def launch_napari():

--- a/plantseg/run_plantseg.py
+++ b/plantseg/run_plantseg.py
@@ -25,12 +25,17 @@ def launch_gui():
 
     try:
         PlantSegApp()
-    except KeyError as e:
-        print(f"If you used PlantSeg before, {PATH_CONFIGS} is checked for your custom configurations.")
-        print(f"If KeyError happens, just delete {PATH_CONFIGS} and a new default configs will be put there.")
+    except KeyError:
+        new_location = PATH_CONFIGS.parent / 'old_configs'
+        PATH_CONFIGS.rename(new_location)
         docs_link = "https://kreshuklab.github.io/plant-seg/chapters/getting_started/troubleshooting/#missing-configuration-key-errors"
-        print(f"For more information, please visit {docs_link}")
-        raise e
+        print(
+            f"{PATH_CONFIGS} is checked for your custom configurations."
+            f"Since `KeyError` happened, we moved {PATH_CONFIGS} to {new_location} "
+            f"and a new default configs will be put in {PATH_CONFIGS}. "
+            f"For more information, please visit {docs_link}"
+        )
+        PlantSegApp()
 
 
 def launch_napari():


### PR DESCRIPTION
Fix #274.

Try to improve error message for users to deal with `KeyError` introduced by upgrade.

Maybe we can also just delete the folders for them? @lorenzocerrone 