### PR TITLE
Make VoxelSize iterable and array-like, remove `.is_valid`

### DIFF
--- a/plantseg/core/image.py
+++ b/plantseg/core/image.py
@@ -518,11 +518,11 @@ class PlantSegImage:
 
     def has_valid_voxel_size(self) -> bool:
         """Returns True if the voxel size is valid (not None), False otherwise."""
-        return self.voxel_size.is_valid
+        return self.voxel_size.voxels_size is not None
 
     def has_valid_original_voxel_size(self) -> bool:
         """Returns True if the original voxel size is valid (not None), False otherwise."""
-        return self.original_voxel_size.is_valid
+        return self.original_voxel_size.voxels_size is not None
 
 
 def _load_data(path: Path, key: str | None) -> tuple[np.ndarray, VoxelSize]:

--- a/plantseg/core/voxelsize.py
+++ b/plantseg/core/voxelsize.py
@@ -3,8 +3,6 @@
 This module handles voxel size operations to avoid circular imports with plantseg.core.image.
 """
 
-from typing import Iterator
-
 import numpy as np
 from pydantic import BaseModel, Field, field_validator
 
@@ -52,18 +50,13 @@ class VoxelSize(BaseModel):
         """Voxel size in the z direction, or 1.0 if not defined."""
         return self.voxels_size[0] if self.voxels_size else 1.0  # pylint: disable=unsubscriptable-object
 
-    @property
-    def is_valid(self) -> bool:  # type checker does not recognize the property
-        """Check if the voxel size is valid (i.e., defined)."""
-        return self.voxels_size is not None
-
     def __len__(self) -> int:
         """Return the number of dimensions of the voxel size."""
         if self.voxels_size is None:
             raise ValueError("Voxel size must be defined to get the length")
         return len(self.voxels_size)
 
-    def __iter__(self) -> Iterator[float]:
+    def __iter__(self):
         """Allow the VoxelSize instance to be unpacked as a tuple."""
         if self.voxels_size is None:
             raise ValueError("Voxel size must be defined to iterate")

--- a/plantseg/core/voxelsize.py
+++ b/plantseg/core/voxelsize.py
@@ -5,6 +5,7 @@ This module handles voxel size operations to avoid circular imports with plantse
 
 from typing import Iterator
 
+import numpy as np
 from pydantic import BaseModel, Field, field_validator
 
 from plantseg.functionals.dataprocessing import compute_scaling_factor, compute_scaling_voxelsize
@@ -56,11 +57,22 @@ class VoxelSize(BaseModel):
         """Check if the voxel size is valid (i.e., defined)."""
         return self.voxels_size is not None
 
+    def __len__(self) -> int:
+        """Return the number of dimensions of the voxel size."""
+        if self.voxels_size is None:
+            raise ValueError("Voxel size must be defined to get the length")
+        return len(self.voxels_size)
+
     def __iter__(self) -> Iterator[float]:
         """Allow the VoxelSize instance to be unpacked as a tuple."""
         if self.voxels_size is None:
             raise ValueError("Voxel size must be defined to iterate")
         return iter(self.voxels_size)
+
+    def __array__(self):
+        if self.voxels_size is None:
+            raise ValueError("Voxel size is not defined")
+        return np.array(self.voxels_size)
 
     def as_tuple(self) -> tuple[float, float, float]:
         """Convert VoxelSize to a tuple."""

--- a/plantseg/core/voxelsize.py
+++ b/plantseg/core/voxelsize.py
@@ -1,9 +1,9 @@
 """Voxel size of an image.
 
-This separates from plantseg.core.image to avoid circular imports.
+This module handles voxel size operations to avoid circular imports with plantseg.core.image.
 """
 
-from typing import Optional
+from typing import Iterator
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -15,71 +15,67 @@ class VoxelSize(BaseModel):
     Voxel size of an image.
 
     Attributes:
-        voxels_size (Optional[tuple[float, float, float]]): Size of the voxels in the image.
-        unit (str): Unit of the voxel size, starting with "u", "µ", or "micro".
+        voxels_size (tuple[float, float, float] | None): Size of the voxels in the image.
+        unit (str): Unit of the voxel size, restricted to micrometers (um).
     """
 
-    voxels_size: Optional[tuple[float, float, float]] = None
+    voxels_size: tuple[float, float, float] | None = None
     unit: str = Field(default="um")
 
     @field_validator("voxels_size")
     @classmethod
-    def _check_voxel_size(cls, values: Optional[tuple[float, float, float]]):
-        if values is None:
-            return values
-
-        if any(value <= 0 for value in values):
+    def _check_voxel_size(cls, value: tuple[float, float, float] | None) -> tuple[float, float, float] | None:
+        if value is not None and any(v <= 0 for v in value):
             raise ValueError("Voxel size must be positive")
-
-        return values
+        return value
 
     @field_validator("unit")
     @classmethod
     def _check_unit(cls, value: str) -> str:
         if value.startswith(("u", "µ", "micro")):
             return "um"
-        raise ValueError("Only micrometers (um) are supported, i.e. units starting with 'u', 'µ', or 'micro'")
-
-    def scalefactor_from_voxelsize(self, other: "VoxelSize") -> tuple[float, float, float]:
-        """
-        Compute the scaling factor to rescale an image from the current voxel size to another voxel size.
-        """
-        if self.voxels_size is None or other.voxels_size is None:
-            raise ValueError("Voxel size is not defined, cannot compute scaling factor")
-
-        return compute_scaling_factor(self.voxels_size, other.voxels_size)
-
-    def voxelsize_from_factor(self, factor: tuple[float, float, float]) -> "VoxelSize":
-        """
-        Compute the output voxel size after scaling an image with a given scaling factor.
-        """
-        if self.voxels_size is None:
-            raise ValueError("Voxel size is not defined, cannot compute output voxel size")
-
-        return VoxelSize(voxels_size=compute_scaling_voxelsize(self.voxels_size, factor))
+        raise ValueError("Only micrometers (um) are supported")
 
     @property
     def x(self) -> float:
-        """Safe access to the voxel size in the x direction. Returns 1.0 if the voxel size is not defined."""
-        if self.voxels_size is not None:
-            return self.voxels_size[2]
-        return 1.0
+        """Voxel size in the x direction, or 1.0 if not defined."""
+        return self.voxels_size[2] if self.voxels_size else 1.0  # pylint: disable=unsubscriptable-object
 
     @property
     def y(self) -> float:
-        """Safe access to the voxel size in the y direction. Returns 1.0 if the voxel size is not defined."""
-        if self.voxels_size is not None:
-            return self.voxels_size[1]
-        return 1.0
+        """Voxel size in the y direction, or 1.0 if not defined."""
+        return self.voxels_size[1] if self.voxels_size else 1.0  # pylint: disable=unsubscriptable-object
 
     @property
     def z(self) -> float:
-        """Safe access to the voxel size in the z direction. Returns 1.0 if the voxel size is not defined."""
-        if self.voxels_size is not None:
-            return self.voxels_size[0]
-        return 1.0
+        """Voxel size in the z direction, or 1.0 if not defined."""
+        return self.voxels_size[0] if self.voxels_size else 1.0  # pylint: disable=unsubscriptable-object
 
     @property
-    def is_valid(self) -> bool:
-        """Return True if the voxel size is valid (i.e., not None)."""
+    def is_valid(self) -> bool:  # type checker does not recognize the property
+        """Check if the voxel size is valid (i.e., defined)."""
         return self.voxels_size is not None
+
+    def __iter__(self) -> Iterator[float]:
+        """Allow the VoxelSize instance to be unpacked as a tuple."""
+        if self.voxels_size is None:
+            raise ValueError("Voxel size must be defined to iterate")
+        return iter(self.voxels_size)
+
+    def as_tuple(self) -> tuple[float, float, float]:
+        """Convert VoxelSize to a tuple."""
+        if self.voxels_size is None:
+            raise ValueError("Voxel size must be defined to convert to tuple")
+        return self.voxels_size
+
+    def scalefactor_from_voxelsize(self, other: "VoxelSize") -> tuple[float, float, float]:
+        """Compute the scaling factor to rescale an image from the current voxel size to another."""
+        if self.voxels_size is None or other.voxels_size is None:
+            raise ValueError("Both voxel sizes must be defined to compute the scaling factor")
+        return compute_scaling_factor(self.voxels_size, other.voxels_size)
+
+    def voxelsize_from_factor(self, factor: tuple[float, float, float]) -> "VoxelSize":
+        """Compute the voxel size after scaling with the given factor."""
+        if self.voxels_size is None:
+            raise ValueError("Voxel size must be defined to compute the output voxel size")
+        return VoxelSize(voxels_size=compute_scaling_voxelsize(self.voxels_size, factor))

--- a/plantseg/viewer_napari/widgets/io.py
+++ b/plantseg/viewer_napari/widgets/io.py
@@ -285,8 +285,7 @@ def _on_layer_changed(layer):
     ps_image = PlantSegImage.from_napari_layer(layer)
     if ps_image.has_valid_voxel_size():
         voxel_size_formatted = "("
-        assert ps_image.voxel_size.voxels_size is not None, "`.has_valid_voxel_size()` should return False"
-        for vs in ps_image.voxel_size.voxels_size:
+        for vs in ps_image.voxel_size:
             voxel_size_formatted += f"{vs:.2f}, "
 
         voxel_size_formatted = voxel_size_formatted[:-2] + f") {ps_image.voxel_size.unit}"

--- a/tests/core/test_voxelsize.py
+++ b/tests/core/test_voxelsize.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from pydantic import ValidationError
 
@@ -110,3 +111,12 @@ def test_voxel_size_iter():
     vs_empty = VoxelSize(unit="um")
     with pytest.raises(ValueError):
         list(vs_empty)
+
+
+def test_voxel_size_array():
+    """Test the __array__ method"""
+    vs = VoxelSize(voxels_size=(1.0, 2.0, 3.0), unit="um")
+    np.testing.assert_allclose(vs, [1.0, 2.0, 3.0])
+
+    with pytest.raises(ValueError):
+        np.array(VoxelSize(unit="um"))

--- a/tests/core/test_voxelsize.py
+++ b/tests/core/test_voxelsize.py
@@ -90,14 +90,6 @@ def test_voxel_size_properties():
     assert vs_empty.z == 1.0
 
 
-def test_voxel_size_is_valid():
-    vs = VoxelSize(voxels_size=(1.0, 1.0, 1.0), unit="um")
-    assert vs.is_valid is True
-
-    vs_invalid = VoxelSize(unit="um")
-    assert vs_invalid.is_valid is False
-
-
 def test_voxel_size_iter():
     vs = VoxelSize(voxels_size=(1.0, 2.0, 3.0), unit="um")
     assert list(vs) == [1.0, 2.0, 3.0]

--- a/tests/core/test_voxelsize.py
+++ b/tests/core/test_voxelsize.py
@@ -40,6 +40,14 @@ def test_voxel_size_invalid_initialization():
         VoxelSize(voxels_size=(0.2, 0.1))
 
 
+def test_voxel_size_equality():
+    voxel_size = VoxelSize(voxels_size=(0.5, 1.0, 1.0), unit="um")
+    same_voxel_size = VoxelSize(voxels_size=(0.5, 1.0, 1.0), unit="um")
+    original_voxel_size = VoxelSize(voxels_size=(1.0, 1.0, 1.0), unit="um")
+    assert same_voxel_size == voxel_size, "Pydanctic models should be equal if their attributes are equal"
+    assert original_voxel_size != voxel_size, "Pydanctic models should not be equal if their attributes are not equal"
+
+
 def test_voxel_size_scalefactor_from_voxelsize():
     vs1 = VoxelSize(voxels_size=(1.0, 1.0, 1.0), unit="um")
     vs2 = VoxelSize(voxels_size=(2.0, 2.0, 2.0), unit="um")
@@ -87,3 +95,18 @@ def test_voxel_size_is_valid():
 
     vs_invalid = VoxelSize(unit="um")
     assert vs_invalid.is_valid is False
+
+
+def test_voxel_size_iter():
+    vs = VoxelSize(voxels_size=(1.0, 2.0, 3.0), unit="um")
+    assert list(vs) == [1.0, 2.0, 3.0]
+
+    with pytest.raises(TypeError):
+        assert vs[2] == 3.0, "VoxelSize object is not subscriptable, encouraging users to use .x, .y, .z properties"
+
+    for v in vs:
+        assert v in vs, "VoxelSize object should be iterable"
+
+    vs_empty = VoxelSize(unit="um")
+    with pytest.raises(ValueError):
+        list(vs_empty)

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -9,9 +9,11 @@ class TestIO:
 
     def _check_voxel_size(self, voxel_size):
         assert isinstance(voxel_size, VoxelSize)
-        (
-            np.testing.assert_allclose(voxel_size.voxels_size, self.voxel_size.voxels_size, rtol=1e-5),
-            "Voxel size read from file is not equal to the original voxel size",
+        np.testing.assert_allclose(
+            voxel_size.voxels_size,
+            self.voxel_size,
+            rtol=1e-5,
+            err_msg="Voxel size read from file is not equal to the original voxel size",
         )
 
     def test_create_read_h5(self, path_h5):
@@ -54,7 +56,7 @@ class TestIO:
         # Read the voxel size of the Zarr file
         voxel_size = read_zarr_voxel_size(path_zarr, "raw")
         assert np.allclose(
-            voxel_size.voxels_size, self.voxel_size.voxels_size
+            voxel_size.voxels_size, self.voxel_size
         ), "Voxel size read from Zarr file is not equal to the original voxel size"
 
         data_read2 = smart_load(path_zarr, "raw")


### PR DESCRIPTION
This PR fixes two things:

1. `voxel_size.voxel_size` has been used to get the actual tuple, which is not neat. Now one either uses it directly and let the `__len__`, `__iter__`, and `__array__` handle `None`; or it can be turned into tuple by builtin `tuple()` 
2. There has been an `.is_valid` property, which doesn't really work with type checkers and is almost not used at all. I safely removed it in favour of checking `None` directly.
