### PR TITLE
Fix and integrate lifted multicut widget into agglomeration widget

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: plantseg
-  version: { { RELEASE_VERSION } }
+  version: {{ RELEASE_VERSION }}  # Do not change this line, not even adding space
 
 source:
   path: ..

--- a/plantseg/functionals/segmentation/segmentation.py
+++ b/plantseg/functionals/segmentation/segmentation.py
@@ -255,7 +255,7 @@ def lifted_multicut_from_nuclei_pmaps(
 
     Args:
         boundary_pmaps (np.ndarray): cell boundary prediction, 3D array of shape (Z, Y, X) with values between 0 and 1.
-        nuclei_pmaps (np.ndarray): nuclei predictionMust have the same shape as boundary_pmaps and
+        nuclei_pmaps (np.ndarray): nuclei prediction. Must have the same shape as boundary_pmaps and
             with values between 0 and 1.
         superpixels (np.ndarray): superpixel segmentation. Must have the same shape as boundary_pmaps.
         beta (float): beta parameter for the Multicut. A small value will steer the segmentation towards
@@ -265,6 +265,9 @@ def lifted_multicut_from_nuclei_pmaps(
     Returns:
         segmentation (np.ndarray): Multicut output segmentation
     """
+    if nuclei_pmaps.max() > 1 or nuclei_pmaps.min() < 0:
+        raise ValueError('nuclei_pmaps should be between 0 and 1')
+
     # compute the region adjacency graph
     rag = compute_rag(superpixels)
 
@@ -279,7 +282,11 @@ def lifted_multicut_from_nuclei_pmaps(
 
     # compute lifted multicut features from boundary pmaps
     lifted_uvs, lifted_costs = lifted_problem_from_probabilities(
-        rag, superpixels, input_maps, assignment_threshold, graph_depth=4
+        rag,
+        superpixels.astype('uint32'),
+        input_maps,
+        assignment_threshold,
+        graph_depth=4,
     )
 
     # solve the full lifted problem using the kernighan lin approximation introduced in

--- a/plantseg/tasks/segmentation_tasks.py
+++ b/plantseg/tasks/segmentation_tasks.py
@@ -170,7 +170,7 @@ def lmc_segmentation_task(
             a high-value bias the segmentation towards the over-segmentation. (default: 0.5)
         post_min_size (int): minimal size of the segments after Multicut. (default: 100)
     """
-    if nuclei.semantic_type is SemanticType.PREDICTION or nuclei.semantic_type is SemanticType.IMAGE:
+    if nuclei.semantic_type is SemanticType.PREDICTION or nuclei.semantic_type is SemanticType.RAW:
         lmc = lifted_multicut_from_nuclei_pmaps
         extra_key = "nuclei_pmaps"
     else:

--- a/plantseg/viewer_napari/containers.py
+++ b/plantseg/viewer_napari/containers.py
@@ -13,7 +13,6 @@ from plantseg.viewer_napari.widgets import (
     widget_fix_over_under_segmentation_from_nuclei,
     widget_gaussian_smoothing,
     widget_infos,
-    widget_lifted_multicut,
     widget_open_file,
     widget_proofreading_initialisation,
     widget_redo,
@@ -95,7 +94,6 @@ def get_extras_tab():
     container = MainWindow(
         widgets=[
             widget_add_custom_model,
-            widget_lifted_multicut,
         ],
         labels=False,
     )

--- a/plantseg/viewer_napari/widgets/__init__.py
+++ b/plantseg/viewer_napari/widgets/__init__.py
@@ -16,7 +16,7 @@ from plantseg.viewer_napari.widgets.proofreading import (
     widget_split_and_merge_from_scribbles,
     widget_undo,
 )
-from plantseg.viewer_napari.widgets.segmentation import widget_agglomeration, widget_dt_ws, widget_lifted_multicut
+from plantseg.viewer_napari.widgets.segmentation import widget_agglomeration, widget_dt_ws
 
 __all__ = [
     # Data processing
@@ -33,7 +33,6 @@ __all__ = [
     "widget_dt_ws",
     "widget_agglomeration",
     # Extra - Segmentation
-    "widget_lifted_multicut",
     "widget_add_custom_model",
     # Proofreading
     "widget_proofreading_initialisation",

--- a/plantseg/viewer_napari/widgets/prediction.py
+++ b/plantseg/viewer_napari/widgets/prediction.py
@@ -18,7 +18,7 @@ from plantseg.core.zoo import model_zoo
 from plantseg.tasks.prediction_tasks import unet_prediction_task
 from plantseg.viewer_napari import log
 from plantseg.viewer_napari.widgets.proofreading import widget_split_and_merge_from_scribbles
-from plantseg.viewer_napari.widgets.segmentation import widget_agglomeration, widget_dt_ws, widget_lifted_multicut
+from plantseg.viewer_napari.widgets.segmentation import widget_agglomeration, widget_dt_ws
 from plantseg.viewer_napari.widgets.utils import schedule_task
 
 ALL_CUDA_DEVICES = [f'cuda:{i}' for i in range(torch.cuda.device_count())]
@@ -167,7 +167,6 @@ def widget_unet_prediction(
         widgets_to_update=[
             widget_dt_ws.image,
             widget_agglomeration.image,
-            widget_lifted_multicut.image,
             widget_split_and_merge_from_scribbles.image,
         ],
     )

--- a/plantseg/viewer_napari/widgets/segmentation.py
+++ b/plantseg/viewer_napari/widgets/segmentation.py
@@ -117,66 +117,6 @@ def _on_mode_changed(mode: str):
 
 ########################################################################################################################
 #                                                                                                                      #
-# Lifted Multicut Segmentation Widget                                                                                  #
-#                                                                                                                      #
-########################################################################################################################
-
-
-@magicgui(
-    call_button='Run Lifted MultiCut',
-    image={
-        'label': 'Boundary image',
-        'tooltip': 'Raw boundary image or boundary prediction to use as input for Lifted Multicut.',
-    },
-    nuclei={
-        'label': 'Nuclei',
-        'tooltip': 'Nuclei binary prediction or Nuclei segmentation.',
-    },
-    superpixels={
-        'label': 'Over-segmentation',
-        'tooltip': 'Over-segmentation labels layer to use as input for clustering.',
-    },
-    beta={
-        'label': 'Under/Over segmentation factor',
-        'tooltip': 'A low value will increase under-segmentation tendency '
-        'and a large value increase over-segmentation tendency.',
-        'widget_type': 'FloatSlider',
-        'max': 1.0,
-        'min': 0.0,
-    },
-    minsize={
-        'label': 'Minimum segment size',
-        'tooltip': 'Minimum segment size allowed in voxels.',
-    },
-)
-def widget_lifted_multicut(
-    image: Image,
-    nuclei: Image | Labels,
-    superpixels: Labels,
-    beta: float = 0.5,
-    minsize: int = 100,
-) -> Future[LayerDataTuple]:
-    ps_image = PlantSegImage.from_napari_layer(image)
-    ps_labels = PlantSegImage.from_napari_layer(superpixels)
-    ps_nuclei = PlantSegImage.from_napari_layer(nuclei)
-
-    widgets_to_update = [widget_proofreading_initialisation.segmentation]
-
-    return schedule_task(
-        lmc_segmentation_task,
-        task_kwargs={
-            "boundary_pmap": ps_image,
-            "superpixels": ps_labels,
-            "nuclei": ps_nuclei,
-            "beta": beta,
-            "post_min_size": minsize,
-        },
-        widgets_to_update=widgets_to_update,
-    )
-
-
-########################################################################################################################
-#                                                                                                                      #
 # DT Watershed Segmentation Widget                                                                                     #
 #                                                                                                                      #
 ########################################################################################################################
@@ -253,7 +193,6 @@ def widget_dt_ws(
         },
         widgets_to_update=[
             widget_agglomeration.superpixels,
-            widget_lifted_multicut.superpixels,
             widget_remove_false_positives_by_foreground.segmentation,
         ],
     )

--- a/plantseg/viewer_napari/widgets/segmentation.py
+++ b/plantseg/viewer_napari/widgets/segmentation.py
@@ -18,7 +18,12 @@ from plantseg.viewer_napari.widgets.utils import schedule_task
 ########################################################################################################################
 
 STACKED = [('2D Watershed', True), ('3D Watershed', False)]
-AGGLOMERATION_MODES = [('GASP', 'gasp'), ('MutexWS', 'mutex_ws'), ('MultiCut', 'multicut')]
+AGGLOMERATION_MODES = [
+    ('GASP', 'gasp'),
+    ('MutexWS', 'mutex_ws'),
+    ('MultiCut', 'multicut'),
+    ('LiftedMultiCut', 'lmc'),
+]
 
 
 @magicgui(
@@ -30,6 +35,10 @@ AGGLOMERATION_MODES = [('GASP', 'gasp'), ('MutexWS', 'mutex_ws'), ('MultiCut', '
     superpixels={
         'label': 'Over-segmentation',
         'tooltip': 'Over-segmentation labels layer to use as input for clustering.',
+    },
+    nuclei={
+        'label': 'Nuclei',
+        'tooltip': 'Nuclei foreground prediction or segmentation.',
     },
     mode={
         'label': 'Agglomeration mode',
@@ -54,6 +63,7 @@ AGGLOMERATION_MODES = [('GASP', 'gasp'), ('MutexWS', 'mutex_ws'), ('MultiCut', '
 def widget_agglomeration(
     image: Image,
     superpixels: Labels,
+    nuclei: Image | Labels | None = None,
     mode: str = AGGLOMERATION_MODES[0][1],
     beta: float = 0.6,
     minsize: int = 100,
@@ -66,6 +76,23 @@ def widget_agglomeration(
 
     widgets_to_update = [widget_proofreading_initialisation.segmentation]
 
+    if mode == 'lmc':
+        if nuclei is None:
+            log("Nuclei layer is required for Lifted MultiCut segmentation", thread="Lifted MultiCut", level="error")
+        else:
+            ps_nuclei = PlantSegImage.from_napari_layer(nuclei)
+        return schedule_task(
+            lmc_segmentation_task,
+            task_kwargs={
+                "boundary_pmap": ps_image,
+                "superpixels": ps_labels,
+                "nuclei": ps_nuclei,
+                "beta": beta,
+                "post_min_size": minsize,
+            },
+            widgets_to_update=widgets_to_update,
+        )
+
     return schedule_task(
         clustering_segmentation_task,
         task_kwargs={
@@ -77,6 +104,15 @@ def widget_agglomeration(
         },
         widgets_to_update=widgets_to_update,
     )
+
+
+@widget_agglomeration.mode.changed.connect
+def _on_mode_changed(mode: str):
+    if mode == 'lmc':
+        widget_agglomeration.nuclei.show()
+    else:
+        widget_agglomeration.nuclei.value = None
+        widget_agglomeration.nuclei.hide()
 
 
 ########################################################################################################################


### PR DESCRIPTION
This PR fixes the semantic type and data type errors for lifted multicut, and integrate it into agglomeration widget:

GASP:

![image](https://github.com/user-attachments/assets/860f5a80-fb73-4aa3-bd87-d20df9de458a)

LMC:

![image](https://github.com/user-attachments/assets/9ffb88f7-5146-4c68-9fcb-1739062c6166)
