### PR TITLE
fix h5 export

### DIFF
--- a/plantseg/core/image.py
+++ b/plantseg/core/image.py
@@ -642,7 +642,7 @@ def save_image(
 
     if file_format == "tiff":
         file_path_name = directory / f"{file_name}_{custom_key}.tiff"
-        create_tiff(file_path_name, data, voxel_size, layout=image.image_layout.value)
+        create_tiff(path=file_path_name, stack=data, voxel_size=voxel_size, layout=image.image_layout.value)
 
     elif file_format == "zarr":
         file_path_name = directory / f"{file_name}.zarr"
@@ -655,7 +655,7 @@ def save_image(
 
     elif file_format == "h5":
         file_path_name = directory / f"{file_name}.h5"
-        create_h5(file_path_name, data, voxel_size, key=custom_key)
+        create_h5(path=file_path_name, stack=data, voxel_size=voxel_size, key=custom_key)
 
     else:
         raise ValueError(f"File format {file_format} not recognized, should be tiff, h5 or zarr")

--- a/plantseg/core/image.py
+++ b/plantseg/core/image.py
@@ -648,7 +648,7 @@ def save_image(
         file_path_name = directory / f"{file_name}.zarr"
         create_zarr(
             path=file_path_name,
-            data=data,
+            stack=data,
             voxel_size=voxel_size,
             key=custom_key,
         )

--- a/plantseg/io/h5.py
+++ b/plantseg/io/h5.py
@@ -146,6 +146,13 @@ def create_h5(
         mode (str): mode to open the h5 file ['w', 'a'].
 
     """
+
+    if key is None:
+        raise ValueError("Key is required to create a dataset in a h5 file.")
+
+    if key == "":
+        raise ValueError("Key cannot be empty to create a dataset in a h5 file.")
+
     with h5py.File(path, mode) as f:
         if key in f:
             del f[key]

--- a/plantseg/io/zarr.py
+++ b/plantseg/io/zarr.py
@@ -149,6 +149,13 @@ def create_zarr(
         mode (str): The mode to open the Zarr file ['w', 'a'].
 
     """
+
+    if key is None:
+        raise ValueError("Key cannot be None.")
+
+    if key == "":
+        raise ValueError("Key cannot be empty.")
+
     zarr_file = zarr.open_group(path, mode)
     zarr_file.create_dataset(key, data=stack, compression="gzip", overwrite=True)
     zarr_file[key].attrs["element_size_um"] = voxel_size.voxels_size

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from plantseg.core.voxelsize import VoxelSize
 from plantseg.io import smart_load
@@ -10,7 +11,7 @@ class TestIO:
     def _check_voxel_size(self, voxel_size):
         assert isinstance(voxel_size, VoxelSize)
         np.testing.assert_allclose(
-            voxel_size.voxels_size,
+            voxel_size,
             self.voxel_size,
             rtol=1e-5,
             err_msg="Voxel size read from file is not equal to the original voxel size",
@@ -22,6 +23,12 @@ class TestIO:
         # Create an HDF5 file
         data = np.random.rand(10, 10, 10)
         create_h5(path_h5, data, "raw", voxel_size=self.voxel_size)
+
+        # Create an HDF5 file with empty name causes an error
+        with pytest.raises(ValueError):
+            create_h5(path_h5, data, "", voxel_size=self.voxel_size)
+        with pytest.raises(ValueError):
+            create_h5(path_h5, data, None, voxel_size=self.voxel_size)
 
         # Read the HDF5 file
         data_read = load_h5(path_h5, "raw")
@@ -45,6 +52,12 @@ class TestIO:
         data = np.random.rand(10, 10, 10)
         create_zarr(path_zarr, data, "raw", voxel_size=self.voxel_size)
 
+        # Create a Zarr file with empty name causes an error
+        with pytest.raises(ValueError):
+            create_zarr(path_zarr, data, "", voxel_size=self.voxel_size)
+        with pytest.raises(ValueError):
+            create_zarr(path_zarr, data, None, voxel_size=self.voxel_size)
+
         # Read the Zarr file
         data_read = load_zarr(path_zarr, "raw")
         assert np.array_equal(data, data_read), "Data read from Zarr file is not equal to the original data"
@@ -56,7 +69,7 @@ class TestIO:
         # Read the voxel size of the Zarr file
         voxel_size = read_zarr_voxel_size(path_zarr, "raw")
         assert np.allclose(
-            voxel_size.voxels_size, self.voxel_size
+            voxel_size, self.voxel_size
         ), "Voxel size read from Zarr file is not equal to the original voxel size"
 
         data_read2 = smart_load(path_zarr, "raw")

--- a/tests/tasks/test_io_tasks.py
+++ b/tests/tasks/test_io_tasks.py
@@ -1,0 +1,173 @@
+import numpy as np
+import pytest
+
+from plantseg.core import ImageProperties, PlantSegImage, VoxelSize
+from plantseg.core.image import ImageLayout, SemanticType
+from plantseg.tasks.io_tasks import export_image_task, import_image_task
+
+
+@pytest.mark.parametrize(
+    "shape, layout, export_format",
+    [
+        ((32, 64, 64), ImageLayout.ZYX, 'tiff'),
+        ((32, 64, 64), ImageLayout.ZYX, 'h5'),
+        ((32, 64, 64), ImageLayout.ZYX, 'zarr'),
+        ((64, 64), ImageLayout.YX, 'tiff'),
+        ((64, 64), ImageLayout.YX, 'h5'),
+        ((64, 64), ImageLayout.YX, 'zarr'),
+    ],
+)
+def test_image_io_round_trip(tmp_path, shape, layout, export_format):
+    mock_data = np.random.rand(*shape).astype('float32')
+
+    property = ImageProperties(
+        name='test',
+        voxel_size=VoxelSize(voxels_size=(1.0, 1.0, 1.0), unit='um'),
+        semantic_type=SemanticType.RAW,
+        image_layout=layout,
+        original_voxel_size=VoxelSize(voxels_size=(1.0, 1.0, 1.0), unit='um'),
+    )
+    image = PlantSegImage(data=mock_data, properties=property)
+
+    export_image_task(
+        image=image,
+        output_directory=tmp_path,
+        output_file_name='test',
+        custom_key_suffix="raw",
+        file_format=export_format,
+        dtype='float32',
+    )
+
+    if export_format == 'tiff':
+        file_path = tmp_path / 'test_raw.tiff'
+        key = None
+    elif export_format == 'h5':
+        file_path = tmp_path / 'test.h5'
+        key = 'raw'
+    else:
+        file_path = tmp_path / 'test.zarr'
+        key = 'raw'
+
+    imported_image: PlantSegImage = import_image_task(
+        input_path=file_path,
+        key=key,
+        image_name='tesi_import',
+        semantic_type='raw',
+        stack_layout=layout,
+        m_slicing=None,
+    )
+
+    original_data = image.get_data()
+    imported_data = imported_image.get_data()
+
+    assert np.allclose(original_data, imported_data)
+    assert original_data.max() <= 1.0  # check if the normalization is applied
+    assert imported_data.max() <= 1.0
+
+    assert image.voxel_size == imported_image.voxel_size
+    assert image.semantic_type == imported_image.semantic_type
+    assert image.image_layout == imported_image.image_layout
+
+
+@pytest.mark.parametrize(
+    "shape, layout, export_format",
+    [
+        ((32, 64, 64), ImageLayout.ZYX, 'tiff'),
+        ((32, 64, 64), ImageLayout.ZYX, 'h5'),
+        ((32, 64, 64), ImageLayout.ZYX, 'zarr'),
+        ((64, 64), ImageLayout.YX, 'tiff'),
+        ((64, 64), ImageLayout.YX, 'h5'),
+        ((64, 64), ImageLayout.YX, 'zarr'),
+    ],
+)
+def test_label_io_round_trip(tmp_path, shape, layout, export_format):
+    mock_data = np.random.randint(0, 10, size=shape).astype('uint16')
+
+    property = ImageProperties(
+        name='test',
+        voxel_size=VoxelSize(voxels_size=(1.0, 1.0, 1.0), unit='um'),
+        semantic_type=SemanticType.SEGMENTATION,
+        image_layout=layout,
+        original_voxel_size=VoxelSize(voxels_size=(1.0, 1.0, 1.0), unit='um'),
+    )
+    image = PlantSegImage(data=mock_data, properties=property)
+
+    export_image_task(
+        image=image,
+        output_directory=tmp_path,
+        output_file_name='test',
+        custom_key_suffix="raw",
+        file_format=export_format,
+        dtype='uint16',
+    )
+
+    if export_format == 'tiff':
+        file_path = tmp_path / 'test_raw.tiff'
+        key = None
+    elif export_format == 'h5':
+        file_path = tmp_path / 'test.h5'
+        key = 'raw'
+    else:
+        file_path = tmp_path / 'test.zarr'
+        key = 'raw'
+
+    imported_image: PlantSegImage = import_image_task(
+        input_path=file_path,
+        key=key,
+        image_name='tesi_import',
+        semantic_type='segmentation',
+        stack_layout=layout,
+        m_slicing=None,
+    )
+
+    original_data = image.get_data()
+    imported_data = imported_image.get_data()
+
+    assert np.allclose(original_data, imported_data)
+    assert original_data.max() > 1.0  # check if the normalization is not applied
+    assert imported_data.max() > 1.0
+
+    assert image.voxel_size == imported_image.voxel_size
+    assert image.semantic_type == imported_image.semantic_type
+    assert image.image_layout == imported_image.image_layout
+
+
+def test_io_slicing_trip(tmp_path):
+    shape = (32, 64, 64)
+    layout = ImageLayout.ZYX
+    export_format = 'tiff'
+    mock_data = np.random.randint(0, 10, size=shape).astype('uint16')
+
+    property = ImageProperties(
+        name='test',
+        voxel_size=VoxelSize(voxels_size=(1.0, 1.0, 1.0), unit='um'),
+        semantic_type=SemanticType.SEGMENTATION,
+        image_layout=layout,
+        original_voxel_size=VoxelSize(voxels_size=(1.0, 1.0, 1.0), unit='um'),
+    )
+    image = PlantSegImage(data=mock_data, properties=property)
+
+    export_image_task(
+        image=image,
+        output_directory=tmp_path,
+        output_file_name='test',
+        custom_key_suffix="raw",
+        file_format=export_format,
+        dtype='uint16',
+    )
+
+    file_path = tmp_path / 'test_raw.tiff'
+    key = None
+
+    imported_image: PlantSegImage = import_image_task(
+        input_path=file_path,
+        key=key,
+        image_name='tesi_import',
+        semantic_type='segmentation',
+        stack_layout=layout,
+        m_slicing="5:10,:, :50",
+    )
+
+    imported_data = imported_image.get_data()
+
+    assert imported_data.shape == (5, 64, 50)


### PR DESCRIPTION
- fix #334 
- fix similar bug in export zarr
- add key check when exporting zarr/h5 to avoid hard to parse errors
- add task io testing 