### PR TITLE
Match conda recipe and include `package_data` logo

### DIFF
--- a/.github/workflows/build-and-test-package.yml
+++ b/.github/workflows/build-and-test-package.yml
@@ -55,7 +55,7 @@ jobs:
       # Create a Conda environment for testing
       - name: Create PlantSeg Test Environment
         run: |
-          conda create -n plant-seg -c local -c conda-forge pyqt plantseg pytest pytest-qt pytest-cov pytest-mock requests-mock
+          conda create -n plant-seg -c local -c conda-forge plantseg pytest pytest-qt pytest-cov pytest-mock requests-mock
 
       # Run tests using pytest
       - name: Run Tests with Pytest

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,8 +19,8 @@ requirements:
     - pip
 
   run:
-    - python
-    - pytorch
+    - python >=3.9
+    - pytorch >=1.7.0
     - tifffile
     - h5py
     - zarr
@@ -28,11 +28,12 @@ requirements:
     - python-elf
     - python-graphviz
     - scikit-image
-    - bioimageio.core>=0.6.5
+    - bioimageio.core >=0.6.5
     - napari
+    - pyqt
     - requests
     - pyyaml
-    - pydantic>2
+    - pydantic >2
 
 test:
   imports:

--- a/docs/chapters/getting_started/installation.md
+++ b/docs/chapters/getting_started/installation.md
@@ -56,7 +56,6 @@ PlantSeg can be installed directly by executing in the terminal (or PowerShell o
         mamba create -n plant-seg -c pytorch -c nvidia -c conda-forge pytorch cpuonly plant-seg --no-channel-priority
         ```
 
-
 === "Windows"
 
     * NVIDIA GPU version, CUDA=12.x
@@ -82,7 +81,7 @@ PlantSeg can be installed directly by executing in the terminal (or PowerShell o
     * Apple silicon version
 
         ```bash
-        mamba create -n plant-seg -c pytorch -c conda-forge python=3.11 pytorch::pytorch pyqt plant-seg --no-channel-priority
+        mamba create -n plant-seg -c pytorch -c conda-forge python=3.11 pytorch::pytorch plant-seg --no-channel-priority
         ```
 
 If you used older versions of PlantSeg, please delete the old config files in `~/.plantseg_models/configs/` after installing new PlantSeg.
@@ -93,24 +92,14 @@ Please refer to the [PyTorch](https://pytorch.org/get-started/locally/) website 
 
 ## Optional dependencies
 
-If you want to use the headless mode of PlantSeg, you need to install `dask[distributed]`:
-
-```bash
-conda activate plant-seg
-mamba install dask distributed
-```
-
-Some types of compressed tiff files require an additional package to be load correctly (e.g.: Zlib, ZSTD, LZMA, ...).
-To run PlantSeg on those stacks, you need to install `imagecodecs`.
-In the terminal:
+Certain compressed TIFF files (e.g., Zlib, ZSTD, LZMA formats) require additional codecs to be processed correctly by PlantSeg. To handle such files, install the `imagecodecs` package:
 
 ```bash
 conda activate plant-seg
 pip install imagecodecs
 ```
 
-Experimental support for SimpleITK watershed segmentation has been added to PlantSeg version 1.1.8.
-These features can be used only after installing the SimpleITK package:
+If you plan to use SimpleITK-based watershed segmentation, you will need to install `SimpleITK` as an additional dependency:
 
 ```bash
 conda activate plant-seg

--- a/environment-elife.yml
+++ b/environment-elife.yml
@@ -1,4 +1,4 @@
-name: plant_seg
+name: plant-seg-elife
 channels:
   - pytorch
   - cpape
@@ -136,4 +136,3 @@ dependencies:
     - werkzeug==0.16.0
     - wrapt==1.11.2
 prefix: /home/lcerrone_local/miniconda3/envs/plant_seg
-

--- a/environment.yaml
+++ b/environment.yaml
@@ -17,6 +17,7 @@ dependencies:
   - scikit-image
   - bioimageio.core>=0.6.5
   # GUI
+  - pyqt
   - napari
   # Other
   - requests

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ setup(
     version=__version__,  # noqa: F821
     packages=find_packages(exclude=["tests", "evaluation"]),
     include_package_data=True,
+    package_data={
+        'plantseg': ['resources/logo_white.png'],
+    },
     description='PlantSeg is a tool for cell instance aware segmentation in densely packed 3D volumetric images.',
     author='Lorenzo Cerrone, Adrian Wolny',
     url='https://github.com/kreshuklab/plant-seg',


### PR DESCRIPTION
This PR fixes two problems:

1. Conda recipe on conda-forge is different from plantseg repo.
2. Plantseg logo was not even included into the package. It was only showing on dev env where the repo exists.