### PR TITLE
Proofreading improvements

### DIFF
--- a/plantseg/core/image.py
+++ b/plantseg/core/image.py
@@ -112,7 +112,7 @@ class ImageProperties(BaseModel):
     voxel_size: VoxelSize
     image_layout: ImageLayout
     original_voxel_size: VoxelSize
-    original_name: str | None = None
+    source_file_name: str | None = None
 
     @property
     def dimensionality(self) -> ImageDimensionality:
@@ -266,7 +266,7 @@ class PlantSegImage:
             raise ValueError("Voxel size not found in metadata")
         new_voxel_size = VoxelSize(**metadata["voxel_size"])
 
-        original_name = metadata.get("original_name", None)
+        source_file_name = metadata.get("source_file_name", None)
 
         # Loading from napari layer, the id needs to be present in the metadata
         # If not present, the layer is corrupted
@@ -281,7 +281,7 @@ class PlantSegImage:
             voxel_size=new_voxel_size,
             image_layout=image_layout,
             original_voxel_size=original_voxel_size,
-            original_name=original_name,
+            source_file_name=source_file_name,
         )
 
         if image_type != properties.image_type:
@@ -517,8 +517,8 @@ class PlantSegImage:
         return self._properties.original_voxel_size
 
     @property
-    def original_name(self) -> str | None:
-        return self._properties.original_name
+    def source_file_name(self) -> str | None:
+        return self._properties.source_file_name
 
     @property
     def name(self) -> str:
@@ -607,7 +607,7 @@ def import_image(
         voxel_size=voxel_size,
         image_layout=image_layout,
         original_voxel_size=voxel_size,
-        original_name=image_name,
+        source_file_name=path.stem,
     )
 
     return PlantSegImage(data=data, properties=image_properties)
@@ -662,7 +662,7 @@ def save_image(
     Args:
         image (PlantSegImage): input image to be saved to disk
         export_directory (Path): output directory path where the image will be saved
-        name_pattern (str): output file name pattern, can contain the {image_name} or {original_name} tokens
+        name_pattern (str): output file name pattern, can contain the {image_name} or {file_name} tokens
             to be replaced in the final file name.
         key (str | None): key for the image (used only for h5 and zarr formats).
         scale_to_origin (bool): scale the voxel size to the original one
@@ -677,8 +677,8 @@ def save_image(
 
     name_pattern = name_pattern.replace("{image_name}", image.name)
 
-    if image.original_name is not None:
-        name_pattern = name_pattern.replace("{original_name}", image.original_name)
+    if image.source_file_name is not None:
+        name_pattern = name_pattern.replace("{file_name}", image.source_file_name)
 
     if export_format == "tiff":
         file_path_name = directory / f"{name_pattern}.tiff"

--- a/plantseg/io/h5.py
+++ b/plantseg/io/h5.py
@@ -158,7 +158,7 @@ def create_h5(
             del f[key]
         f.create_dataset(key, data=stack, compression="gzip")
         # save voxel_size
-        if voxel_size is not None:
+        if voxel_size is not None and voxel_size.voxels_size is not None:
             f[key].attrs["element_size_um"] = voxel_size.voxels_size
 
 

--- a/plantseg/tasks/io_tasks.py
+++ b/plantseg/tasks/io_tasks.py
@@ -73,7 +73,7 @@ def import_image_task(
 def export_image_task(
     image: PlantSegImage,
     export_directory: Path,
-    name_pattern: str = "{original_name}_export",
+    name_pattern: str = "{file_name}_export",
     key: str | None = None,
     scale_to_origin: bool = True,
     export_format: str = "tiff",
@@ -85,7 +85,7 @@ def export_image_task(
     Args:
         image (PlantSegImage): input image to be saved to disk
         export_directory (Path): output directory path where the image will be saved
-        name_pattern (str): output file name pattern, can contain the {image_name} or {original_name} tokens
+        name_pattern (str): output file name pattern, can contain the {image_name} or {file_name} tokens
             to be replaced in the final file name.
         key (str | None): key for the image (used only for h5 and zarr formats).
         scale_to_origin (bool): scale the voxel size to the original one

--- a/plantseg/viewer_napari/containers.py
+++ b/plantseg/viewer_napari/containers.py
@@ -2,6 +2,7 @@ from magicgui.widgets import Container
 
 from plantseg.viewer_napari.widgets import (
     widget_add_custom_model,
+    widget_add_custom_model_toggl,
     widget_agglomeration,
     widget_clean_scribble,
     widget_cropping,
@@ -21,6 +22,7 @@ from plantseg.viewer_napari.widgets import (
     widget_rescaling,
     widget_save_state,
     widget_set_biggest_instance_to_zero,
+    widget_set_voxel_size,
     widget_show_info,
     widget_split_and_merge_from_scribbles,
     widget_undo,
@@ -37,6 +39,7 @@ def get_data_io_tab():
             widget_open_file,
             widget_export_image,
             widget_export_headless_workflow,
+            widget_set_voxel_size,
             widget_show_info,
             widget_infos,
         ],
@@ -62,6 +65,8 @@ def get_segmentation_tab():
     container = Container(
         widgets=[
             widget_unet_prediction,
+            widget_add_custom_model,
+            widget_add_custom_model_toggl,
             widget_dt_ws,
             widget_agglomeration,
         ],
@@ -77,16 +82,6 @@ def get_postprocessing_tab():
             widget_set_biggest_instance_to_zero,
             widget_remove_false_positives_by_foreground,
             widget_fix_over_under_segmentation_from_nuclei,
-        ],
-        labels=False,
-    )
-    return container
-
-
-def get_extras_tab():
-    container = Container(
-        widgets=[
-            widget_add_custom_model,
         ],
         labels=False,
     )

--- a/plantseg/viewer_napari/viewer.py
+++ b/plantseg/viewer_napari/viewer.py
@@ -14,7 +14,7 @@ from plantseg.viewer_napari.widgets.proofreading import setup_proofreading_keybi
 
 def run_viewer():
     viewer = napari.Viewer(title='PlantSeg v2')
-    setup_proofreading_keybindings(viewer)
+    setup_proofreading_keybindings(viewer=viewer)
 
     # Create and add tabs
     for _containers, name in [

--- a/plantseg/viewer_napari/viewer.py
+++ b/plantseg/viewer_napari/viewer.py
@@ -3,7 +3,6 @@ import napari
 from plantseg.viewer_napari import log
 from plantseg.viewer_napari.containers import (
     get_data_io_tab,
-    get_extras_tab,
     get_postprocessing_tab,
     get_preprocessing_tab,
     get_proofreading_tab,
@@ -19,11 +18,10 @@ def run_viewer():
     # Create and add tabs
     for _containers, name in [
         (get_data_io_tab(), 'Input/Output'),
-        (get_preprocessing_tab(), 'Image Processing'),
+        (get_preprocessing_tab(), 'Preprocessing'),
         (get_segmentation_tab(), 'Segmentation'),
-        (get_postprocessing_tab(), 'Label Processing'),
+        (get_postprocessing_tab(), 'Postprocessing'),
         (get_proofreading_tab(), 'Proofreading'),
-        (get_extras_tab(), 'Models'),
     ]:
         viewer.window.add_dock_widget(_containers, name=name, tabify=True)
 

--- a/plantseg/viewer_napari/widgets/__init__.py
+++ b/plantseg/viewer_napari/widgets/__init__.py
@@ -13,9 +13,14 @@ from plantseg.viewer_napari.widgets.io import (
     widget_export_image,
     widget_infos,
     widget_open_file,
+    widget_set_voxel_size,
     widget_show_info,
 )
-from plantseg.viewer_napari.widgets.prediction import widget_add_custom_model, widget_unet_prediction
+from plantseg.viewer_napari.widgets.prediction import (
+    widget_add_custom_model,
+    widget_add_custom_model_toggl,
+    widget_unet_prediction,
+)
 from plantseg.viewer_napari.widgets.proofreading import (
     widget_add_label_to_corrected,
     widget_clean_scribble,
@@ -41,6 +46,7 @@ __all__ = [
     "widget_export_headless_workflow",
     "widget_show_info",
     "widget_infos",
+    "widget_set_voxel_size",
     # Main - Prediction
     "widget_unet_prediction",
     # Main - Segmentation
@@ -48,6 +54,7 @@ __all__ = [
     "widget_agglomeration",
     # Extra
     "widget_add_custom_model",
+    "widget_add_custom_model_toggl",
     "widget_relabel",
     "widget_set_biggest_instance_to_zero",
     # Proofreading

--- a/plantseg/viewer_napari/widgets/dataprocessing.py
+++ b/plantseg/viewer_napari/widgets/dataprocessing.py
@@ -82,7 +82,7 @@ def widget_gaussian_smoothing(image: Image, sigma: float = 1.0, update_other_wid
         "tooltip": "This must be a shape layer with a rectangle XY overlaying the area to crop.",
     },
     crop_z={
-        "label": "Z slices [Start, End)",
+        "label": "Z slices [start, end)",
         "tooltip": "Number of z slices to take next to the current selection.\nSTART is included, END is not.",
         "widget_type": "RangeSlider",
         "max": 100,
@@ -421,7 +421,7 @@ def _on_rescale_order_changed(order):
 
 
 @magicgui(
-    call_button="Remove False Instances by Foreground",
+    call_button="Remove Objects with Low Foreground Probability",
     segmentation={
         "label": "Segmentation",
         "tooltip": "Segmentation layer to remove false positives.",
@@ -469,16 +469,18 @@ def widget_remove_false_positives_by_foreground(
     call_button='Split/Merge Instances by Nuclei',
     segmentation_cells={'label': 'Cell instances'},
     segmentation_nuclei={'label': 'Nuclear instances'},
-    boundary_pmaps={'label': 'Boundary Pmap/Image'},
+    boundary_pmaps={'label': 'Boundary image'},
     threshold={
-        'label': 'Threshold',
+        'label': 'Boundary threshold',
+        'tooltip': 'Threshold range for merging (first value) and splitting (second value) cells. ',
         'widget_type': 'FloatRangeSlider',
         'max': 100,
         'min': 0,
         'step': 0.1,
     },
     quantile={
-        'label': 'Nuclei Quantile',
+        'label': 'Nuclei size filter',
+        'tooltip': 'Quantile range to filter nuclei size, ignoring outliers.',
         'widget_type': 'FloatRangeSlider',
         'max': 100,
         'min': 0,

--- a/plantseg/viewer_napari/widgets/io.py
+++ b/plantseg/viewer_napari/widgets/io.py
@@ -224,7 +224,7 @@ def widget_export_image(
     export_format: str = "tiff",
     key: str = "raw",
     scale_to_origin: bool = True,
-    data_type: str = "float32",
+    data_type: str = "uint16",
 ) -> None:
     timer = time.time()
     log("export_image_task started", thread="Export stacks", level="info")

--- a/plantseg/viewer_napari/widgets/io.py
+++ b/plantseg/viewer_napari/widgets/io.py
@@ -193,7 +193,7 @@ def _on_done(*args):  # Required by magicgui. pylint: disable=unused-argument
     name_pattern={
         "label": "Export name pattern",
         "tooltip": "Pattern for the exported file name. Use {image_name} to include the layer name, "
-        "or {original_name} to include the original file name.",
+        "or {file_name} to include the original file name.",
     },
     export_format={
         "label": "Export format",
@@ -220,7 +220,7 @@ def _on_done(*args):  # Required by magicgui. pylint: disable=unused-argument
 def widget_export_image(
     image: Layer | None = None,
     directory: Path = Path.home(),
-    name_pattern: str = "{image_name}_export",
+    name_pattern: str = "{file_name}_export",
     export_format: str = "tiff",
     key: str = "raw",
     scale_to_origin: bool = True,

--- a/plantseg/viewer_napari/widgets/proofreading.py
+++ b/plantseg/viewer_napari/widgets/proofreading.py
@@ -712,7 +712,7 @@ def widget_split_and_merge_from_scribbles(
     worker.start()
 
 
-@magicgui(call_button='Freeze correct labels')
+@magicgui(call_button='Extract Corrected labels')
 def widget_filter_segmentation() -> None:
     """Extracts corrected labels from the segmentation.
 

--- a/plantseg/viewer_napari/widgets/segmentation.py
+++ b/plantseg/viewer_napari/widgets/segmentation.py
@@ -1,6 +1,5 @@
 from magicgui import magicgui
 from napari.layers import Image, Labels, Layer
-from napari.types import LayerDataTuple
 
 from plantseg.core.image import ImageLayout, PlantSegImage
 from plantseg.tasks.segmentation_tasks import clustering_segmentation_task, dt_watershed_task, lmc_segmentation_task
@@ -78,6 +77,7 @@ def widget_agglomeration(
     widgets_to_update = [widget_proofreading_initialisation.segmentation]
 
     if mode == 'lmc':
+        assert isinstance(nuclei, (Image, Labels)), "Nuclei must be an Image or Labels layer."
         ps_nuclei = PlantSegImage.from_napari_layer(nuclei)
         return schedule_task(
             lmc_segmentation_task,
@@ -133,7 +133,7 @@ def _on_mode_changed(mode: str):
         'choices': STACKED,
     },
     threshold={
-        'label': 'Threshold',
+        'label': 'Boundary threshold',
         'tooltip': 'A low value will increase over-segmentation tendency '
         'and a large value increase under-segmentation tendency.',
         'widget_type': 'FloatSlider',
@@ -146,7 +146,7 @@ def _on_mode_changed(mode: str):
     },
     # Advanced parameters
     show_advanced={
-        'label': 'Show Advanced Parameters',
+        'label': 'Show advanced parameters',
         'tooltip': 'Show advanced parameters for the Watershed algorithm.',
         'widget_type': 'CheckBox',
     },

--- a/plantseg/viewer_napari/widgets/utils.py
+++ b/plantseg/viewer_napari/widgets/utils.py
@@ -83,7 +83,7 @@ def schedule_task(task: Callable, task_kwargs: dict, widgets_to_update: list[Wid
         log(f"{task_name} complete in {timer:.2f}s", thread='Task')
 
         if isinstance(task_result, PlantSegImage):
-            add_ps_image_to_viewer(task_result)
+            add_ps_image_to_viewer(task_result, replace=True)
             setup_layers_suggestions(out_name=task_result.name, widgets=widgets_to_update)
 
         elif isinstance(task_result, (tuple, list)):
@@ -92,7 +92,7 @@ def schedule_task(task: Callable, task_kwargs: dict, widgets_to_update: list[Wid
                     raise ValueError(f"Task {task_name} returned an unexpected value {task_result}")
 
             for ps_im in task_result:
-                add_ps_image_to_viewer(ps_im)
+                add_ps_image_to_viewer(ps_im, replace=True)
             setup_layers_suggestions(out_name=task_result[-1].name, widgets=widgets_to_update)
 
         elif task_result is None:

--- a/tests/headless/test_headless.py
+++ b/tests/headless/test_headless.py
@@ -53,7 +53,7 @@ def test_create_workflow(tmp_path):
 
     config['inputs']['input_path']['value'] = [str(path_tiff_1), str(path_tiff_2)]
     config['inputs']['export_directory']['value'] = str(tmp_path / 'output')
-    config['inputs']['name_pattern']['value'] = '{original_name}_export'
+    config['inputs']['name_pattern']['value'] = '{file_name}_export'
 
     with open(tmp_path / 'workflow.yaml', 'w') as file:
         yaml.dump(config, file)

--- a/tests/tasks/test_io_tasks.py
+++ b/tests/tasks/test_io_tasks.py
@@ -26,7 +26,7 @@ def test_image_io_round_trip(tmp_path, shape, layout, export_format):
         semantic_type=SemanticType.RAW,
         image_layout=layout,
         original_voxel_size=VoxelSize(voxels_size=(1.0, 1.0, 1.0), unit='um'),
-        original_name='test',
+        source_file_name='test',
     )
     image = PlantSegImage(data=mock_data, properties=property)
 

--- a/tests/tasks/test_prediction_tasks.py
+++ b/tests/tasks/test_prediction_tasks.py
@@ -9,7 +9,7 @@ from plantseg.tasks.prediction_tasks import unet_prediction_task
 @pytest.mark.parametrize(
     "shape, layout, model_name",
     [
-        ((32, 64, 64), ImageLayout.ZYX, 'generic_confocal_3D_unet'),
+        ((8, 64, 64), ImageLayout.ZYX, 'generic_confocal_3D_unet'),
         ((64, 64), ImageLayout.YX, 'confocal_2D_unet_ovules_ds2x'),
     ],
 )


### PR DESCRIPTION
- [x]  General cleanup of proofreading code. Remove redundant copying of the data in the proofreading handler. 
- [x]  Add methods to save and construct a plantseg image from h5.
- [x]  Save proofreading state to disk as h5
- [x] Proofreading seems to work now on all orientations (to be tested more extensively)

Unrelated changes:
- [x] Imrpove defaults in import task
- [x] Fix cropping for 2D
- [x] Handle gracefully edge case when the rectangle is not drawn in XY plane 
- [x] Fix #351  


@qin-yu test it a bit and let me know if the behavior did not change