### PR TITLE
fix: allow more runtime errors in `find_batch_size()`

### DIFF
--- a/plantseg/functionals/prediction/utils/size_finder.py
+++ b/plantseg/functionals/prediction/utils/size_finder.py
@@ -170,6 +170,10 @@ def find_batch_size(
                 if "out of memory" in str(e):
                     batch_size //= 2
                     break
+                elif "less than INT_MAX elements" in str(e):
+                    logger.warning(f"Encountered '{e}', unexpected but continuing with reduced batch size.")
+                    batch_size //= 2
+                    break
                 else:
                     raise
             finally:

--- a/plantseg/functionals/prediction/utils/size_finder.py
+++ b/plantseg/functionals/prediction/utils/size_finder.py
@@ -168,14 +168,15 @@ def find_batch_size(
                 _ = model(x)
             except RuntimeError as e:
                 if "out of memory" in str(e):
-                    batch_size //= 2
-                    break
-                elif "less than INT_MAX elements" in str(e):
-                    logger.warning(f"Encountered '{e}', unexpected but continuing with reduced batch size.")
+                    logger.info(f"Encountered '{e}' at batch size {batch_size}, halving it.")
                     batch_size //= 2
                     break
                 else:
-                    raise
+                    logger.warning(
+                        f"Encountered '{e}' at batch size {batch_size}, unexpected but continuing with halved batch size."
+                    )
+                    batch_size //= 2
+                    break
             finally:
                 del x
                 torch.cuda.empty_cache()


### PR DESCRIPTION
This PR attempts to fix #358.

1. `find_batch_size()` now catches and handles all runtime errors during probing.  
2. A specific issue, where VRAM is sufficient but the layer can only support `INT_MAX` elements, is tested.  
