### PR TITLE
fix: allow but warn all runtime errors in 3D `find_a_max_patch_shape()`

### DIFF
--- a/plantseg/functionals/prediction/utils/size_finder.py
+++ b/plantseg/functionals/prediction/utils/size_finder.py
@@ -101,9 +101,11 @@ def find_a_max_patch_shape(
                     low = mid + 1  # Try larger patches
                 except RuntimeError as e:
                     if "out of memory" in str(e):
+                        logger.info(f"Encountered '{e}' at patch shape {patch_shape}, reducing it.")
                         high = mid - 1  # Try smaller patches
                     else:
-                        raise
+                        logger.warning(f"Encountered '{e}' at patch shape {patch_shape}, unexpected but continuing.")
+                        high = mid - 1  # Try smaller patches
                 finally:
                     del x
                     torch.cuda.empty_cache()


### PR DESCRIPTION
In this PR I only updated the `try ... catch ...` for 3D. The 2D case won't be limited by the layer `INT_MAX` constraint because the largest patch is `1 x 3200 x 3200` which is also tested now.

Tests are updated too.