### PR TITLE
ci(docs): fetch all git history/tags/branches for MkDocs dates

### DIFF
--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -3,8 +3,7 @@ on:
   push:
     branches:
       - master
-      - plantsegv2
-      - qy/plantsegv2
+      - qy/add-plantseg-v1-installation
 
 permissions:
   contents: write
@@ -19,6 +18,8 @@ jobs:
       # Checkout the repository
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
 
       # Set up Qt libraries (required for PyQt applications)
       - name: Set Up Qt Libraries


### PR DESCRIPTION
This PR fixes #365 

References:

- https://github.com/timvink/mkdocs-git-revision-date-localized-plugin?tab=readme-ov-file#note-when-using-build-systems-like-github-actions
- https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches