### PR TITLE
Fix smart load | Make extension check case-insensitive

### DIFF
--- a/plantseg/core/image.py
+++ b/plantseg/core/image.py
@@ -331,7 +331,7 @@ class PlantSegImage:
         if isinstance(path, str):
             path = Path(path)
 
-        if path.suffix not in H5_EXTENSIONS:
+        if path.suffix.lower() not in H5_EXTENSIONS:
             raise ValueError(f"File format {path.suffix} not supported, should be one of {H5_EXTENSIONS}")
 
         key = key if key is not None else self.name

--- a/plantseg/headless/headless.py
+++ b/plantseg/headless/headless.py
@@ -51,7 +51,7 @@ def parse_import_image_task(input_path, allow_dir: bool) -> list[Path]:
     else:
         raise ValueError(f"Path {input_path} is not a file or a directory.")
 
-    list_files = [f for f in list_files if f.suffix in allowed_data_format]
+    list_files = [f for f in list_files if f.suffix.lower() in allowed_data_format]
     if not list_files:
         raise ValueError(f"No valid files found in {input_path}.")
 

--- a/plantseg/io/h5.py
+++ b/plantseg/io/h5.py
@@ -13,7 +13,7 @@ H5_KEYS = ["raw", "prediction", "segmentation"]
 
 
 def _validate_h5_file(path: Path) -> None:
-    assert path.suffix in H5_EXTENSIONS, f"File extension not supported. Supported extensions: {H5_EXTENSIONS}"
+    assert path.suffix.lower() in H5_EXTENSIONS, f"File extension not supported. Supported extensions: {H5_EXTENSIONS}"
     assert path.exists(), f"File not found: {path}"
 
 
@@ -73,7 +73,7 @@ def load_h5(
         np.ndarray: dataset as numpy array
     """
 
-    assert path.suffix in H5_EXTENSIONS, f"File extension not supported. Supported extensions: {H5_EXTENSIONS}"
+    assert path.suffix.lower() in H5_EXTENSIONS, f"File extension not supported. Supported extensions: {H5_EXTENSIONS}"
     assert path.exists(), f"File not found: {path}"
 
     with h5py.File(path, "r") as f:

--- a/plantseg/io/io.py
+++ b/plantseg/io/io.py
@@ -85,7 +85,7 @@ def smart_load_with_vs(path: Path, key: str | None = None, default=load_tiff) ->
     if ext in PIL_EXTENSIONS:
         return load_pil(path), None
 
-    if ".zarr" in path.suffixes:
+    if ext in ZARR_EXTENSIONS:
         return load_zarr(path, key), read_zarr_voxel_size(path, key)
 
     else:

--- a/plantseg/io/io.py
+++ b/plantseg/io/io.py
@@ -89,5 +89,5 @@ def smart_load_with_vs(path: Path, key: str | None = None, default=load_tiff) ->
         return load_zarr(path, key), read_zarr_voxel_size(path, key)
 
     else:
-        logger.warning(f"No default found for {ext}, reverting to default loader.")
-        return default(path)
+        logger.warning(f"No default found for {ext}, reverting to default loader with no voxel size reader.")
+        return default(path), None

--- a/plantseg/io/io.py
+++ b/plantseg/io/io.py
@@ -32,7 +32,7 @@ def smart_load(path: Path, key: str | None = None, default=load_tiff) -> np.ndar
         >>> data = smart_load('path/to/file.h5', key='raw')
 
     """
-    ext = path.suffix
+    ext = (path.suffix).lower()
     if key == "":
         key = None
 
@@ -72,7 +72,7 @@ def smart_load_with_vs(path: Path, key: str | None = None, default=load_tiff) ->
         >>> data = smart_load('path/to/file.h5', key='raw')
 
     """
-    ext = path.suffix
+    ext = (path.suffix).lower()
     if key == "":
         key = None
 

--- a/plantseg/viewer_napari/widgets/io.py
+++ b/plantseg/viewer_napari/widgets/io.py
@@ -126,7 +126,7 @@ def generate_layer_name(path: Path, dataset_key: str) -> str:
 
 def look_up_dataset_keys(path: Path):
     path = _return_value_if_widget(path)
-    ext = path.suffix
+    ext = path.suffix.lower()
 
     if ext in H5_EXTENSIONS:
         widget_open_file.dataset_key.show()

--- a/plantseg/viewer_napari/widgets/proofreading.py
+++ b/plantseg/viewer_napari/widgets/proofreading.py
@@ -370,7 +370,7 @@ class ProofreadingHandler:
     def save_state_to_disk(self, filepath: Path, raw: Image | None, pmap: Image | None = None):
         """Saves the current state to disk as an HDF5 file."""
 
-        if filepath.suffix not in H5_EXTENSIONS:
+        if filepath.suffix.lower() not in H5_EXTENSIONS:
             log(
                 f'Invalid file extension: {filepath.suffix}. Please use a valid HDF5 file extensions: {H5_EXTENSIONS}',
                 thread='Save State',


### PR DESCRIPTION
Adeleh from University of Potsdam sent me email about PlantSeg can't open her .JPG and .TIF files. This PR improves the extension checking throughout PlantSeg and makes `smart_load()`s consistent.