### PR TITLE
CI/tests on pr

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,66 @@
+name: Run tests
+
+on:
+  pull_request:
+    branches:
+      - "master"
+
+jobs:
+  build-and-test-linux:
+    runs-on: ubuntu-22.04
+    env:
+      DISPLAY: ":99.0"
+
+    steps:
+      # Checkout the repository
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      # Set up Qt libraries (required for PyQt applications)
+      - name: Set Up Qt Libraries
+        uses: tlambert03/setup-qt-libs@v1
+
+      # Start X virtual framebuffer for GUI testing
+      - name: Start Xvfb
+        run: |
+          /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid \
+          --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
+
+      # Set the PlantSeg version based on the current date and time
+      - name: Set PlantSeg Version
+        run: echo "RELEASE_VERSION=$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
+
+      # Print the PlantSeg version name (for debugging purposes)
+      - name: Print PlantSeg Version
+        run: echo $RELEASE_VERSION
+
+      # Set up Miniconda
+      - name: Set Up Miniforge
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: 3.11
+          miniforge-version: latest
+          mamba-version: "*"
+          channels: local,conda-forge
+          environment-file: "environment-dev.yaml"
+          activate-environment: "plant-seg-dev"
+          conda-remove-defaults: true
+
+      # Display available Conda environments (for debugging purposes)
+      - name: List Conda Environments
+        shell: bash -l {0}
+        run: conda info --envs
+
+      # Run tests using pytest
+      - name: Run Tests with Pytest
+        shell: bash -l {0}
+        run: |
+          conda activate plant-seg-dev
+          pytest -s --cov --cov-report=xml
+          conda deactivate
+
+      # Upload Codecov report
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.2.0
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       - "master"
 
 jobs:
-  build-and-test-linux:
+  test-linux:
     runs-on: ubuntu-22.04
     env:
       DISPLAY: ":99.0"

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -31,6 +31,7 @@ dependencies:
   - pydantic>2,<2.10  # 2.10 cause problem spec-bioimage-io/issues/663
   # Test
   - pytest
+  - pytest-cov
   - pytest-qt
   - pytest-mock
   - requests-mock


### PR DESCRIPTION
Run test on PR.

I also replaced conda with miniforge without the anaconda channels, as those are commercial.
Not building the conda package every time does lead to a slight speed-up, alongside the newer mamba version.