### PR TITLE
ci: add workflow for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release new version
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump-type:
+        description: "Bump type"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+          - pre_l
+          - pre_n
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Bump version
+        id: bump
+        uses: callowayproject/bump-my-version@master
+        with:
+          args: ${{ inputs.bump-type }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check version
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          echo "Version was bumped from ${{ steps.bump.outputs.previous-version }} to ${{ steps.bump.outputs.current-version }}!"
+
+      - name: Release
+        uses: softprops/action-gh-release@v2.2.1
+        # if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+          tag_name: ${{ steps.bump.outputs.current-version }}
+          name: ${{ steps.bump.outputs.current-version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          make_latest: true


### PR DESCRIPTION
Workflow is manually triggered to bumb the version, make a tag, and make a github release, including a changelog.