### PR TITLE
build: pin xarray due to #396

### DIFF
--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - qy/fix-conda-no-plugin
+      - qy/pin-xarray-bioimageio-core
 
 permissions:
   contents: write

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -29,7 +29,8 @@ requirements:
     - python-elf
     - python-graphviz
     - scikit-image
-    - bioimageio.core >=0.6.5
+    - bioimageio.core >=0.6.5,<=0.7.0
+    - xarray<2025.3.0  # 2025.3.0 cause problem plant-seg/issues/396
     - napari
     - pyqt
     - requests
@@ -43,6 +44,7 @@ test:
     - pytest
   run:
     - pytest
+
 about:
   home: https://kreshuklab.github.io/plant-seg/
   license: MIT

--- a/environment-dev-apple.yaml
+++ b/environment-dev-apple.yaml
@@ -18,7 +18,8 @@ dependencies:
   - python-elf
   - python-graphviz
   - scikit-image
-  - bioimageio.core>=0.6.5
+  - bioimageio.core>=0.6.5,<=0.7.0
+  - xarray<2025.3.0  # 2025.3.0 cause problem plant-seg/issues/396
   # GUI
   - pyqt
   - napari

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -21,7 +21,8 @@ dependencies:
   - python-elf
   - python-graphviz
   - scikit-image
-  - bioimageio.core>=0.6.5
+  - bioimageio.core>=0.6.5,<=0.7.0
+  - xarray<2025.3.0  # 2025.3.0 cause problem plant-seg/issues/396
   # GUI
   - pyqt
   - napari

--- a/environment.yaml
+++ b/environment.yaml
@@ -15,7 +15,8 @@ dependencies:
   - python-elf
   - python-graphviz
   - scikit-image
-  - bioimageio.core>=0.6.5
+  - bioimageio.core>=0.6.5,<=0.7.0
+  - xarray<2025.3.0  # 2025.3.0 cause problem plant-seg/issues/396
   # GUI
   - pyqt
   - napari


### PR DESCRIPTION
Pin `xarray` to avoid breaking changes in ops module

Recent breaking changes in the `xarray.ops` module are not yet handled by `bioimageio.core`, which then breaks documentation screenshots and causes confusion for new users. To prevent this, we now pin `xarray` to `<2025.3.0` until upstream compatibility is restored.

Related: 
- #396 