### PR TITLE
ci: add commitlint workflow for PR title enforcement

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -11,12 +11,14 @@ jobs:
       - uses: actions/checkout@v3
 
       # Install commitlint and the conventional config
+      # Ref: https://github.com/conventional-changelog/commitlint/blob/27dad55a69e7c531e2c57a3b1db7ead40fa3a304/%40commitlint/config-conventional/README.md?plain=1#L11-L12
       - name: Install Commitlint
         run: |
           npm install --save-dev @commitlint/config-conventional @commitlint/cli
           echo "export default {extends: ['@commitlint/config-conventional']};" > commitlint.config.js
 
       # Lint the PR title against Conventional Commits
+      # Ref: https://commitlint.js.org/reference/cli.html
       - name: Lint PR title
         run: |
           echo "${{ github.event.pull_request.title }}" \

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           # dump the PR title into a file
           echo "${{ github.event.pull_request.title }}" > pr_title.txt
-          # lint that file
+          # lint that file (I guess there is no way to just feed a string)
           npx commitlint \
-            --config node_modules/@commitlint/config-conventional \
+            --config @commitlint/config-conventional \
             --edit pr_title.txt

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -16,8 +16,11 @@ jobs:
           npm install --no-save @commitlint/{cli,config-conventional}
 
       # Lint the PR title against Conventional Commits
-      - name: Lint PR Title
+      - name: Lint PR title
         run: |
+          # dump the PR title into a file
+          echo "${{ github.event.pull_request.title }}" > pr_title.txt
+          # lint that file
           npx commitlint \
             --config node_modules/@commitlint/config-conventional \
-            --text "${{ github.event.pull_request.title }}"
+            --edit pr_title.txt

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -18,9 +18,5 @@ jobs:
       # Lint the PR title against Conventional Commits
       - name: Lint PR title
         run: |
-          # dump the PR title into a file
-          echo "${{ github.event.pull_request.title }}" > pr_title.txt
-          # lint that file (I guess there is no way to just feed a string)
-          npx commitlint \
-            --config @commitlint/config-conventional \
-            --edit pr_title.txt
+          echo "${{ github.event.pull_request.title }}" \
+          | npx commitlint --config @commitlint/config-conventional

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -13,10 +13,11 @@ jobs:
       # Install commitlint and the conventional config
       - name: Install Commitlint
         run: |
-          npm install --no-save @commitlint/{cli,config-conventional}
+          npm install --save-dev @commitlint/config-conventional @commitlint/cli
+          echo "export default {extends: ['@commitlint/config-conventional']};" > commitlint.config.js
 
       # Lint the PR title against Conventional Commits
       - name: Lint PR title
         run: |
           echo "${{ github.event.pull_request.title }}" \
-          | npx commitlint --config @commitlint/config-conventional
+          | npx commitlint --config commitlint.config.js

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -20,5 +20,4 @@ jobs:
         run: |
           npx commitlint \
             --config node_modules/@commitlint/config-conventional \
-            --env GITHUB_HEAD_REF \
-            --edit "${{ github.event.pull_request.title }}"
+            --text "${{ github.event.pull_request.title }}"

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -1,0 +1,24 @@
+name: "PR Title: Conventional Commit Lint"
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  lint_pr_title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # Install commitlint and the conventional config
+      - name: Install Commitlint
+        run: |
+          npm install --no-save @commitlint/{cli,config-conventional}
+
+      # Lint the PR title against Conventional Commits
+      - name: Lint PR Title
+        run: |
+          npx commitlint \
+            --config node_modules/@commitlint/config-conventional \
+            --env GITHUB_HEAD_REF \
+            --edit "${{ github.event.pull_request.title }}"


### PR DESCRIPTION
Just squash-merged a PR but forgot to conventional commit it T_T... Adding a CI to force me remembering. This PR adds a CI that checks the PR title, so the default commit message for squash merge will be valid. Reference: [here](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).

Named it differently than `ci: add commitlint workflow for PR title enforcement` to test.