### PR TITLE
build: lift `xarray` and `pydantic` restrictions

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -40,15 +40,14 @@ requirements:
     - python-elf
     - python-graphviz
     - scikit-image
-    - bioimageio.core >=0.6.5,<=0.7.0
-    - xarray<2025.3.0 # 2025.3.0 cause problem plant-seg/issues/396
+    - bioimageio.core>=0.8.0
+    - xarray
     - qtpy
     - pyqt
     - napari
     - requests
     - pyyaml
-    - pydantic >2,<2.10 # 2.10 cause problem spec-bioimage-io/issues/663
-    - xarray <2025.3.0
+    - pydantic>2
 
 test:
   imports:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -41,7 +41,6 @@ requirements:
     - python-graphviz
     - scikit-image
     - bioimageio.core>=0.8.0
-    - xarray
     - qtpy
     - pyqt
     - napari

--- a/environment-dev-apple.yaml
+++ b/environment-dev-apple.yaml
@@ -7,6 +7,7 @@ channels:
   # - defaults
 dependencies:
   - python
+  - pip
   # Neural Network and GPU
   - pytorch::pytorch
   - torchvision
@@ -18,17 +19,19 @@ dependencies:
   - python-elf
   - python-graphviz
   - scikit-image
-  - bioimageio.core>=0.6.5,<=0.7.0
-  - xarray<2025.3.0  # 2025.3.0 cause problem plant-seg/issues/396
+  - bioimageio.core>=0.8.0
+  - xarray
   # GUI
+  - qtpy
   - pyqt
   - napari
   # Other
   - requests
   - pyyaml
-  - pydantic>2,<2.10  # 2.10 cause problem spec-bioimage-io/issues/663
+  - pydantic>2
   # Test
   - pytest
+  - pytest-cov
   - pytest-qt
   - pytest-mock
   - requests-mock

--- a/environment-dev-apple.yaml
+++ b/environment-dev-apple.yaml
@@ -20,7 +20,6 @@ dependencies:
   - python-graphviz
   - scikit-image
   - bioimageio.core>=0.8.0
-  - xarray
   # GUI
   - qtpy
   - pyqt

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -18,7 +18,6 @@ dependencies:
   - python-graphviz
   - scikit-image
   - bioimageio.core>=0.8.0
-  - xarray
   # GUI
   - qtpy
   - pyqt

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -17,8 +17,8 @@ dependencies:
   - python-elf
   - python-graphviz
   - scikit-image
-  - bioimageio.core>=0.6.5,<=0.7.0
-  - xarray<2025.3.0 # 2025.3.0 cause problem plant-seg/issues/396
+  - bioimageio.core>=0.8.0
+  - xarray
   # GUI
   - qtpy
   - pyqt
@@ -26,7 +26,7 @@ dependencies:
   # Other
   - requests
   - pyyaml
-  - pydantic>2,<2.10 # 2.10 cause problem spec-bioimage-io/issues/663
+  - pydantic>2
   # Test
   - pytest
   - pytest-cov

--- a/environment.yaml
+++ b/environment.yaml
@@ -15,7 +15,6 @@ dependencies:
   - python-graphviz
   - scikit-image
   - bioimageio.core>=0.8.0
-  - xarray
   # GUI
   - qtpy
   - pyqt

--- a/environment.yaml
+++ b/environment.yaml
@@ -14,8 +14,8 @@ dependencies:
   - python-elf
   - python-graphviz
   - scikit-image
-  - bioimageio.core>=0.6.5,<=0.7.0
-  - xarray<2025.3.0 # 2025.3.0 cause problem plant-seg/issues/396
+  - bioimageio.core>=0.8.0
+  - xarray
   # GUI
   - qtpy
   - pyqt
@@ -23,6 +23,6 @@ dependencies:
   # Other
   - requests
   - pyyaml
-  - pydantic>2,<2.10 # 2.10 cause problem spec-bioimage-io/issues/663
+  - pydantic>2
   - pip:
       - -e .


### PR DESCRIPTION
- #396 
  - has been fixed since release v0.8.0 of biomageio.core
- https://github.com/bioimage-io/spec-bioimage-io/issues/663 
  - has been fixed since release [v2.11.0](https://github.com/pydantic/pydantic/releases/tag/v2.11.0) of Pydantic ([#11008](https://github.com/pydantic/pydantic/pull/11008))