### PR TITLE
fix: update layer names after renaming

### DIFF
--- a/plantseg/viewer_napari/viewer.py
+++ b/plantseg/viewer_napari/viewer.py
@@ -30,6 +30,8 @@ def run_viewer():
     ]:
         this_widget = viewer.window.add_dock_widget(_containers, name=name, tabify=True)
         this_widget.setFixedWidth(666)
+
+    # update layer drop-down menus on layer selection
     viewer.layers.selection.events.active.connect(on_layer_rename_prediction())
     viewer.layers.selection.events.active.connect(on_layer_rename_io())
     viewer.layers.selection.events.active.connect(on_layer_rename_dataprocessing())

--- a/plantseg/viewer_napari/viewer.py
+++ b/plantseg/viewer_napari/viewer.py
@@ -9,7 +9,11 @@ from plantseg.viewer_napari.containers import (
     get_proofreading_tab,
     get_segmentation_tab,
 )
+from plantseg.viewer_napari.widgets.dataprocessing import on_layer_rename_dataprocessing
+from plantseg.viewer_napari.widgets.io import on_layer_rename_io
+from plantseg.viewer_napari.widgets.prediction import on_layer_rename_prediction
 from plantseg.viewer_napari.widgets.proofreading import setup_proofreading_keybindings
+from plantseg.viewer_napari.widgets.segmentation import on_layer_rename_segmentation
 
 
 def run_viewer():
@@ -26,6 +30,10 @@ def run_viewer():
     ]:
         this_widget = viewer.window.add_dock_widget(_containers, name=name, tabify=True)
         this_widget.setFixedWidth(666)
+    viewer.layers.selection.events.active.connect(on_layer_rename_prediction())
+    viewer.layers.selection.events.active.connect(on_layer_rename_io())
+    viewer.layers.selection.events.active.connect(on_layer_rename_dataprocessing())
+    viewer.layers.selection.events.active.connect(on_layer_rename_segmentation())
 
     # Show data tab by default
     viewer.window._dock_widgets["Input/Output"].show()

--- a/plantseg/viewer_napari/widgets/dataprocessing.py
+++ b/plantseg/viewer_napari/widgets/dataprocessing.py
@@ -742,6 +742,8 @@ def widget_image_pair_operations(
 
 
 def on_layer_rename_dataprocessing():
+    """Updates layer drop-down menus"""
+
     def update():
         log(
             "Updating layer names",

--- a/plantseg/viewer_napari/widgets/dataprocessing.py
+++ b/plantseg/viewer_napari/widgets/dataprocessing.py
@@ -739,3 +739,20 @@ def widget_image_pair_operations(
         },
         widgets_to_update=[],
     )
+
+
+def on_layer_rename_dataprocessing():
+    def update():
+        log(
+            "Updating layer names",
+            thread="dataprocessing",
+            level="debug",
+        )
+        widget_image_pair_operations.image1.reset_choices()
+        widget_image_pair_operations.image2.reset_choices()
+        widget_remove_false_positives_by_foreground.foreground.reset_choices()
+        widget_rescaling.image.reset_choices()
+        widget_cropping.image.reset_choices()
+        widget_gaussian_smoothing.image.reset_choices()
+
+    return update

--- a/plantseg/viewer_napari/widgets/io.py
+++ b/plantseg/viewer_napari/widgets/io.py
@@ -513,3 +513,17 @@ def _on_layer_changed(layer):
         f"Layout: {ps_image.image_layout.value}"
     )
     widget_infos.value = str_info
+
+
+def on_layer_rename_io():
+    def update():
+        log(
+            "Updating layer names",
+            thread="io",
+            level="debug",
+        )
+        widget_export_image.image.reset_choices()
+        widget_set_voxel_size.layer.reset_choices()
+        widget_show_info.layer.reset_choices()
+
+    return update

--- a/plantseg/viewer_napari/widgets/io.py
+++ b/plantseg/viewer_napari/widgets/io.py
@@ -516,6 +516,8 @@ def _on_layer_changed(layer):
 
 
 def on_layer_rename_io():
+    """Updates layer drop-down menus"""
+
     def update():
         log(
             "Updating layer names",

--- a/plantseg/viewer_napari/widgets/prediction.py
+++ b/plantseg/viewer_napari/widgets/prediction.py
@@ -468,3 +468,15 @@ def _on_custom_output_type_change(output_type: str):
         widget_add_custom_model.custom_output_type.show()
     else:
         widget_add_custom_model.custom_output_type.hide()
+
+
+def on_layer_rename_prediction():
+    def update():
+        log(
+            "Updating layer names",
+            thread="prediction",
+            level="debug",
+        )
+        widget_unet_prediction.image.reset_choices()
+
+    return update

--- a/plantseg/viewer_napari/widgets/prediction.py
+++ b/plantseg/viewer_napari/widgets/prediction.py
@@ -471,6 +471,8 @@ def _on_custom_output_type_change(output_type: str):
 
 
 def on_layer_rename_prediction():
+    """Updates layer drop-down menus"""
+
     def update():
         log(
             "Updating layer names",

--- a/plantseg/viewer_napari/widgets/segmentation.py
+++ b/plantseg/viewer_napari/widgets/segmentation.py
@@ -252,3 +252,16 @@ def _on_image_changed(image: Image):
                 )
             else:
                 initialised_widget_dt_ws = True
+
+
+def on_layer_rename_segmentation():
+    def update():
+        log(
+            "Updating layer names",
+            thread="segmentation",
+            level="debug",
+        )
+        widget_agglomeration.image.reset_choices()
+        widget_dt_ws.image.reset_choices()
+
+    return update

--- a/plantseg/viewer_napari/widgets/segmentation.py
+++ b/plantseg/viewer_napari/widgets/segmentation.py
@@ -255,6 +255,8 @@ def _on_image_changed(image: Image):
 
 
 def on_layer_rename_segmentation():
+    """Updates layer drop-down menus"""
+
     def update():
         log(
             "Updating layer names",


### PR DESCRIPTION
fixes #198 

This implements updates to all layer drop-down menus on selecting a layer.  
Not the most ideal variant, but triggering on name-change would require a code change everywhere where a layer is created, which would become messy quickly.