### PR TITLE
fix: release version name lagging behind

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,16 +119,19 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+
       - name: Checkout new release
         run: |
           git fetch
           git checkout master
+          git pull
           cat plantseg/__version__.py
 
       - uses: actions/download-artifact@v4
         with:
           name: plantseg-conda-build
           path: ./constructor
+
       - name: Display downloaded files
         run: ls ./constructor
 


### PR DESCRIPTION
The installer name and displayed version in the installer lags one version behind as the git repo state before the gh-action got pulled. 