### PR TITLE
fix: escape sequence (backslash) in f-strings

### DIFF
--- a/plantseg/viewer_napari/widgets/utils.py
+++ b/plantseg/viewer_napari/widgets/utils.py
@@ -40,10 +40,11 @@ def div(text: str = ""):
         # length of white space ~3.5px, char length less, needs to be balanced
         n_ws = int((needed_ws / 4.1) + (text_len * 0.13))
 
+        centered_text = text.center(n_ws, "\u00a0")  # wraps text in non-breaking spaces
         w = Label(
             value=(
                 f"<img src={resources / 'div1.png'}>"
-                f"{text:\u00a0^{n_ws}}"
+                f"{centered_text}"
                 f"<img src={resources / 'div2.png'}>"
             )
         )


### PR DESCRIPTION
This PR fixes the syntax complained by #454: `Cannot use an escape sequence (backslash) in f-strings on Python 3.11 (syntax was added in Python 3.12)`