### PR TITLE
fix: allow nuclei images to be raw, prediction, or segmentation

### DIFF
--- a/plantseg/viewer_napari/widgets/segmentation.py
+++ b/plantseg/viewer_napari/widgets/segmentation.py
@@ -278,7 +278,7 @@ class Segmentation_Tab:
     ) -> None:
         if self.widget_layer_select.prediction.value is None:
             log(
-                "Please load an input image first!",
+                "Please run a prediction first!",
                 thread="Segmentation",
                 level="WARNING",
             )
@@ -377,7 +377,7 @@ class Segmentation_Tab:
 
         self.widget_layer_select.layer.choices = raws
         self.widget_layer_select.prediction.choices = predictions
-        self.widget_layer_select.nuclei.choices = raws
+        self.widget_layer_select.nuclei.choices = raws + predictions + segmentations
         self.widget_layer_select.superpixels.choices = segmentations
 
         # Hide empyt choices

--- a/tests/widgets/test_segmentation.py
+++ b/tests/widgets/test_segmentation.py
@@ -113,7 +113,7 @@ def test_agglomeration_no_layer(segmentation_tab, mocker):
     segmentation_tab.widget_agglomeration()
     mocked_scheduler.assert_not_called()
     mocked_log.assert_called_with(
-        "Please load an input image first!",
+        "Please run a prediction first!",
         thread="Segmentation",
         level="WARNING",
     )


### PR DESCRIPTION
This allows the selection of not only raw images, but also predictions and segmentations as the nuclei image for lmc.

Addresses parts of #458 