### PR TITLE
fix: allow loading of boundary predictions

### DIFF
--- a/plantseg/viewer_napari/widgets/input.py
+++ b/plantseg/viewer_napari/widgets/input.py
@@ -23,6 +23,16 @@ from plantseg.viewer_napari.widgets.utils import (
 )
 
 
+class InputType(Enum):
+    RAW = "Image"
+    PREDICTION = "Boundary"
+    SEGMENTATION = "Segmentation"
+
+    @classmethod
+    def to_choices(cls):
+        return [member.value for member in cls]
+
+
 class PathMode(Enum):
     FILE = "tiff, h5, png, jpg"
     DIR = "zarr"
@@ -116,12 +126,12 @@ class Input_Tab:
             "tooltip": "Define the name of the output layer, default is either image or label.",
         },
         layer_type={
-            "value": ImageType.IMAGE.value,
+            "value": InputType.RAW.value,
             "label": "Layer type",
             "tooltip": "Select if the image is a normal image or a segmentation",
             "widget_type": "RadioButtons",
             "orientation": "horizontal",
-            "choices": ImageType.to_choices(),
+            "choices": InputType.to_choices(),
         },
         dataset_key={
             "label": "Key (h5/zarr only)",
@@ -143,11 +153,6 @@ class Input_Tab:
             "widget_type": "RadioButtons",
             "orientation": "horizontal",
         },
-        update_other_widgets={
-            "value": True,
-            "visible": False,
-            "tooltip": "To allow toggle the update of other widgets in unit tests; invisible to users.",
-        },
     )
     def factory_open_file(
         self,
@@ -158,17 +163,18 @@ class Input_Tab:
         stack_layout: str,
         layer_type: str,
         new_layer_name: str,
-        update_other_widgets: bool,
     ) -> None:
         """Open a file and return a napari layer."""
 
         if not self.path_changed_once:
             log("Please select a file to load!", thread="Input")
             return
-        if layer_type == ImageType.IMAGE.value:
+        if layer_type == InputType.RAW.value:
             semantic_type = SemanticType.RAW
-        elif layer_type == ImageType.LABEL.value:
+        elif layer_type == InputType.SEGMENTATION.value:
             semantic_type = SemanticType.SEGMENTATION
+        elif layer_type == InputType.PREDICTION.value:
+            semantic_type = SemanticType.PREDICTION
         else:
             raise ValueError(f"Unknown layer type {layer_type}")
 

--- a/plantseg/viewer_napari/widgets/io.py
+++ b/plantseg/viewer_napari/widgets/io.py
@@ -86,10 +86,6 @@ class PathMode(Enum):
         "widget_type": "RadioButtons",
         "orientation": "horizontal",
     },
-    update_other_widgets={
-        "visible": False,
-        "tooltip": "To allow toggle the update of other widgets in unit tests; invisible to users.",
-    },
 )
 def widget_open_file(
     path_mode: str = PathMode.FILE.value,
@@ -99,7 +95,6 @@ def widget_open_file(
     dataset_key: str | None = None,
     button_key_refresh: bool = True,
     stack_layout: str = ImageLayout.ZYX.value,
-    update_other_widgets: bool = True,
 ) -> None:
     """Open a file and return a napari layer."""
 
@@ -482,12 +477,8 @@ def _on_set_voxel_size_layer_done_set_voxel_size(*args):
         "label": "Select layer",
         "tooltip": "Select the image or label to show the information.",
     },
-    update_other_widgets={
-        "visible": False,
-        "tooltip": "To allow toggle the update of other widgets in unit tests; invisible to users.",
-    },
 )
-def widget_show_info(layer: Layer, update_other_widgets: bool = False) -> None:
+def widget_show_info(layer: Layer) -> None:
     """Show the information of the selected layer."""
 
 

--- a/plantseg/viewer_napari/widgets/preprocessing.py
+++ b/plantseg/viewer_napari/widgets/preprocessing.py
@@ -222,14 +222,8 @@ class Preprocessing_Tab:
             "max": 10.0,
             "min": 0.1,
         },
-        update_other_widgets={
-            "visible": False,
-            "tooltip": "To allow toggle the update of other widgets in unit tests; invisible to users.",
-        },
     )
-    def factory_gaussian_smoothing(
-        self, sigma: float = 1.0, update_other_widgets: bool = True
-    ) -> None:
+    def factory_gaussian_smoothing(self, sigma: float = 1.0) -> None:
         """Apply Gaussian smoothing to an image layer."""
 
         if self.widget_layer_select.layer.value is None:

--- a/tests/widgets/test_input.py
+++ b/tests/widgets/test_input.py
@@ -2,8 +2,12 @@ from pathlib import Path
 
 import pytest
 
-from plantseg.core.image import ImageType
-from plantseg.viewer_napari.widgets.input import Docs_Container, Input_Tab, PathMode
+from plantseg.viewer_napari.widgets.input import (
+    Docs_Container,
+    Input_Tab,
+    InputType,
+    PathMode,
+)
 
 
 @pytest.fixture
@@ -29,9 +33,8 @@ def test_input_tab_open_file(input_tab, mocker):
         "dataset_key": "",
         "button_key_refresh": True,
         "stack_layout": "",
-        "layer_type": ImageType.IMAGE.value,
+        "layer_type": InputType.RAW.value,
         "new_layer_name": "",
-        "update_other_widgets": False,
     }
     input_tab.widget_open_file(**kwargs)
     mocked_scheduler.assert_not_called()


### PR DESCRIPTION
* [x] Allow loading of boundary maps in input dialogue.
* [ ] Allow repeating boundary predictions in advanced menu

fixes #485

