### PR TITLE
ci: upload to codecov during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,11 @@ jobs:
           pytest -s --cov --cov-report=xml
           conda deactivate
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.2.0
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Bump version
         id: bump
         uses: callowayproject/bump-my-version@master


### PR DESCRIPTION
Codecov comparison is not working due to `Missing Base Commit` Maybe branching only from tested commits fixes this.